### PR TITLE
Add option to check no context layer was selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For the corresponding score to be computed, expected values must be provided. Th
 - `expected_aoi_ids`  - Expected AOI identifier / GADM id. 
 - `expected_subregion` - Expected subregion 
 - `expected_dataset_id` - Expected dataset ID (0-8 for current datasets). For queries that may match multiple datasets, separate IDs with semicolons (e.g., "0;1" for DIST-ALERT and another dataset). Can be empty if not applicable.
-- `expected_context_layer` - Expected context layer (varies by dataset). Multiple values can be separated by semicolons if multiple layers are acceptable. Can be empty if not applicable.
+- `expected_context_layer` - Expected context layer (varies by dataset). Multiple values can be separated by semicolons if multiple layers are acceptable. Can be empty if not applicable. Can put `no_selection` to enforce context layer value is empty.
 - `expected_dataset_name` - Expected dataset name (for reference, not evaluated)
 - `expected_start_date` - Expected start date (YYYY-MM-DD or YYYY). For date ranges, use the earliest expected date.
 - `expected_end_date` - Expected end date (YYYY-MM-DD or YYYY). For date ranges, use the latest expected date.

--- a/src/gnw_evals/evaluators/dataset_evaluator.py
+++ b/src/gnw_evals/evaluators/dataset_evaluator.py
@@ -67,7 +67,7 @@ def evaluate_dataset_selection(
     # Context layer matching: if expected is empty, return None (not evaluated)
     if not expected_context_str:
         context_layer_match_score = None
-    elif expected_context_str == "none":
+    elif expected_context_str == "no_selection":
         context_layer_match_score = 1.0 if not actual_context_str else 0.0
     else:
         context_layer_match = expected_context_str == actual_context_str

--- a/src/gnw_evals/evaluators/dataset_evaluator.py
+++ b/src/gnw_evals/evaluators/dataset_evaluator.py
@@ -67,7 +67,7 @@ def evaluate_dataset_selection(
     # Context layer matching: if expected is empty, return None (not evaluated)
     if not expected_context_str:
         context_layer_match_score = None
-    if expected_context_str == "none":
+    elif expected_context_str == "none":
         context_layer_match_score = 1.0 if not actual_context_str else 0.0
     else:
         context_layer_match = expected_context_str == actual_context_str

--- a/src/gnw_evals/evaluators/dataset_evaluator.py
+++ b/src/gnw_evals/evaluators/dataset_evaluator.py
@@ -67,6 +67,8 @@ def evaluate_dataset_selection(
     # Context layer matching: if expected is empty, return None (not evaluated)
     if not expected_context_str:
         context_layer_match_score = None
+    if expected_context_str == "none":
+        context_layer_match_score = 1.0 if not actual_context_str else 0.0
     else:
         context_layer_match = expected_context_str == actual_context_str
         context_layer_match_score = 1.0 if context_layer_match else 0.0

--- a/src/gnw_evals/evaluators/utils.py
+++ b/src/gnw_evals/evaluators/utils.py
@@ -14,7 +14,7 @@ def normalize_value(value) -> str:
     """Normalize values for comparison, handling None, empty strings, and 'None' strings."""
     if value is None or value == "None" or str(value).strip() == "":
         return ""
-    return str(value).strip()
+    return str(value).strip().lower()
 
 
 def normalize_date(date_str: str | None) -> str:

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -505,8 +505,7 @@ def test_dataset_evaluator_none_expected_context_layer():
 
 
 def test_dataset_evaluator_incorrect_expected_context_layer():
-    """Test that incorrect context layer returns 0.0 for context_layer_match_score.
-    """
+    """Test that incorrect context layer returns 0.0 for context_layer_match_score."""
     from gnw_evals.evaluators import evaluate_dataset_selection
 
     agent_state = {

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -476,6 +476,34 @@ def test_dataset_evaluator_missing_expected_context_layer():
     )
 
 
+def test_dataset_evaluator_none_expected_context_layer():
+    """Test that missing expected_context_layer returns 1.0 for context_layer_match_score.
+
+    No actual_context_layer when is expected_context_layer is "none" should return positive score.
+    """
+    from gnw_evals.evaluators import evaluate_dataset_selection
+
+    agent_state = {
+        "dataset": {
+            "dataset_id": "0",
+            "dataset_name": "DIST-ALERT",
+            "context_layer": "",
+        },
+    }
+
+    result = evaluate_dataset_selection(
+        agent_state=agent_state,
+        expected_dataset_id="0",
+        expected_context_layer="none",  # Empty - should return None
+        query="",
+    )
+
+    assert result["dataset_id_match_score"] == 1.0, "Dataset ID should match"
+    assert result["context_layer_match_score"] == 1.0, (
+        "Context layer score should be 1.0 if no context_layer is selected."
+    )
+
+
 def test_data_pull_evaluator_missing_expected_dates():
     """Test that missing expected dates returns None for date_match_score.
 

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -494,13 +494,39 @@ def test_dataset_evaluator_none_expected_context_layer():
     result = evaluate_dataset_selection(
         agent_state=agent_state,
         expected_dataset_id="0",
-        expected_context_layer="no_selection",  # Empty - should return None
+        expected_context_layer="no_selection",  # should assert no_selection
         query="",
     )
 
     assert result["dataset_id_match_score"] == 1.0, "Dataset ID should match"
     assert result["context_layer_match_score"] == 1.0, (
         "Context layer score should be 1.0 if no context_layer is selected."
+    )
+
+
+def test_dataset_evaluator_incorrect_expected_context_layer():
+    """Test that incorrect context layer returns 0.0 for context_layer_match_score.
+    """
+    from gnw_evals.evaluators import evaluate_dataset_selection
+
+    agent_state = {
+        "dataset": {
+            "dataset_id": "0",
+            "dataset_name": "DIST-ALERT",
+            "context_layer": "land_cover",
+        },
+    }
+
+    result = evaluate_dataset_selection(
+        agent_state=agent_state,
+        expected_dataset_id="0",
+        expected_context_layer="driver",  # Empty - should return None
+        query="",
+    )
+
+    assert result["dataset_id_match_score"] == 1.0, "Dataset ID should match"
+    assert result["context_layer_match_score"] == 0.0, (
+        "Context layer score should be 0.0 if since context layers don't match."
     )
 
 

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -494,7 +494,7 @@ def test_dataset_evaluator_none_expected_context_layer():
     result = evaluate_dataset_selection(
         agent_state=agent_state,
         expected_dataset_id="0",
-        expected_context_layer="none",  # Empty - should return None
+        expected_context_layer="no_selection",  # Empty - should return None
         query="",
     )
 


### PR DESCRIPTION
We're adding new contextual layers that have cases where they shouldn't be selected, even if mentioned in the query. For example, the primary forest contextual layer is only available in the tropics, so shouldn't be selected for an AOI in boreal regions. Adding an option to write "none" for contextual_layer to assert that no contextual layer should be chosen for a query.