### PR TITLE
Expected text

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For the corresponding score to be computed, expected values must be provided. Th
 - `expected_start_date` - Expected start date (YYYY-MM-DD or YYYY). For date ranges, use the earliest expected date.
 - `expected_end_date` - Expected end date (YYYY-MM-DD or YYYY). For date ranges, use the latest expected date.
 - `expected_answer` - Expected answer text for LLM-as-a-judge comparison. Can be empty if not applicable.
+- `expected_text` - Expected information, phrasing, or behavior that should appear in the final agent response. This is a semantic inclusion check, not an exact match. Use it for text such as "30 x 30 resolution" or instructions such as "clarifies to user that dataset isn't available". Can be empty if not applicable.
 - `expected_clarification` - Boolean flag indicating whether agent should request clarification instead of completing the task (default: `False`)
 - `expected_` 
 

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -213,6 +213,13 @@ def _print_csv_summary(results: list[TestResult]) -> None:
     ]
     print(_metric_line("Charts Answer", charts_scores))
 
+    expected_text_scores = [
+        r.expected_text_match_score
+        for r in results
+        if r.expected_text_match_score is not None
+    ]
+    print(_metric_line("Expected Text Match", expected_text_scores))
+
     clarification_scores = [
         r.clarification_requested_score
         for r in results

--- a/src/gnw_evals/data_handlers/result_exporter.py
+++ b/src/gnw_evals/data_handlers/result_exporter.py
@@ -54,6 +54,7 @@ class ResultExporter:
             "date_match_score",
             "charts_answer_score",
             "agent_answer_score",
+            "expected_text_match_score",
             "clarification_requested_score",
             "execution_time",
             "error",
@@ -118,6 +119,8 @@ class ResultExporter:
             "charts_answer_score",
             "actual_agent_answer",
             "agent_answer_score",
+            "expected_text",
+            "expected_text_match_score",
             # Clarification: Expected vs Actual
             "expected_clarification",
             "actual_clarification_requested",

--- a/src/gnw_evals/data_handlers/result_exporter.py
+++ b/src/gnw_evals/data_handlers/result_exporter.py
@@ -43,6 +43,7 @@ class ResultExporter:
 
         # 1. Summary CSV - just query and scores
         summary_fields = [
+            "test_id",
             "query",
             "eval_set",
             "overall_score",
@@ -75,6 +76,7 @@ class ResultExporter:
         # 2. Detailed CSV - expected vs actual side by side
         detailed_fields = [
             # Basic info
+            "test_id",
             "query",
             "eval_set",
             "thread_id",

--- a/src/gnw_evals/evaluators/answer_evaluator.py
+++ b/src/gnw_evals/evaluators/answer_evaluator.py
@@ -1,11 +1,12 @@
 from typing import Any
 
-from gnw_evals.evaluators.llm_judges import llm_judge
+from gnw_evals.evaluators.llm_judges import llm_judge, llm_judge_expected_text
 
 
 def evaluate_final_answer(
     agent_state: dict[str, Any],
     expected_answer: str,
+    expected_text: str = "",
 ) -> dict[str, Any]:
     """Check if final answer contains key information from expected answer using LLM-as-a-judge.
 
@@ -15,10 +16,13 @@ def evaluate_final_answer(
     Returns TWO separate "answer" scores:
     - charts_answer_score: Compares expected_answer to charts_data[0]["insight"]
     - agent_answer_score: Compares expected_answer to messages[-1].content
+    - expected_text_match_score: Checks whether messages[-1].content includes
+      expected_text semantically
 
     Args:
         agent_state: Final agent state after execution
         expected_answer: Expected answer text
+        expected_text: Expected text, meaning, or behavior to check in agent response
 
     Returns:
         Dict with charts_answer_score, agent_answer_score, and actual values
@@ -49,33 +53,32 @@ def evaluate_final_answer(
             # Fallback for any other format
             actual_agent_answer = str(content) if content else ""
 
-    # If no expected answer, both scores are None
-    if not expected_answer:
-        return {
-            "charts_answer_score": None,
-            "agent_answer_score": None,
-            "actual_charts_answer": actual_charts_answer,
-            "actual_agent_answer": actual_agent_answer,
-        }
-
     # Score charts answer
     charts_answer_score = None
-    if actual_charts_answer:
+    if expected_answer and actual_charts_answer:
         # Has insight (even if empty string), evaluate it
         charts_answer_score = llm_judge(expected_answer, actual_charts_answer)
     # else: No charts data at all, return None (not applicable)
 
     # Score agent answer
     agent_answer_score = None
-    if actual_agent_answer:
+    if expected_answer and actual_agent_answer:
         # Has message response, evaluate it
         agent_answer_score = llm_judge(expected_answer, actual_agent_answer)
     # else: No agent message, return None (not applicable)
+
+    expected_text_match_score = None
+    if expected_text and actual_agent_answer:
+        expected_text_match_score = llm_judge_expected_text(
+            expected_text,
+            actual_agent_answer,
+        )
 
     # Set actual values to None if empty strings for cleaner CSV output
     return {
         "charts_answer_score": charts_answer_score,
         "agent_answer_score": agent_answer_score,
+        "expected_text_match_score": expected_text_match_score,
         "actual_charts_answer": actual_charts_answer or None,
         "actual_agent_answer": actual_agent_answer or None,
     }

--- a/src/gnw_evals/evaluators/data_pull_evaluator.py
+++ b/src/gnw_evals/evaluators/data_pull_evaluator.py
@@ -93,6 +93,7 @@ def evaluate_date_selection(
 def evaluate_data_pull(
     agent_state: dict[str, Any],
     expected_clarification: bool | None = None,
+    expected_answer: str = "",
     min_rows: int = 1,
     query: str = "",
 ) -> dict[str, Any]:
@@ -104,6 +105,7 @@ def evaluate_data_pull(
     Args:
         agent_state: Final agent state after execution
         expected_clarification: Expected clarification behavior (True/False/None)
+        expected_answer: Expected answer text. Data pull is only evaluated when provided.
         min_rows: Minimum number of rows expected
         query: Original user query (kept for compatibility but not used)
 
@@ -132,8 +134,8 @@ def evaluate_data_pull(
     else:
         data_pull_success = True
 
-    # If we expect clarification, data pull evaluation is not applicable
-    if expected_clarification is True:
+    # If we expect clarification or no answer check, data pull evaluation is not applicable.
+    if expected_clarification is True or not expected_answer:
         data_pull_exists_score = None
     else:
         data_pull_exists_score = 1.0 if data_pull_success else 0.0

--- a/src/gnw_evals/evaluators/llm_judges.py
+++ b/src/gnw_evals/evaluators/llm_judges.py
@@ -185,3 +185,57 @@ def llm_judge(expected_answer: str, actual_answer: str):
     # llm_judgement.answer_eval_type
 
     return llm_judgement.score
+
+
+def llm_judge_expected_text(expected_text: str, actual_answer: str) -> int:
+    """Judge whether an answer includes semantically similar expected text."""
+
+    class TextMatchScore(BaseModel):
+        score: int
+
+    JUDGE_PROMPT = ChatPromptTemplate.from_messages(
+        [
+            (
+                "user",
+                """
+                You are evaluating whether an AI-generated response includes
+                the expected information, meaning, or behavior.
+
+                EXPECTED TEXT OR INSTRUCTION:
+                {expected_text}
+
+                ACTUAL AGENT RESPONSE:
+                {actual_answer}
+
+                Return score 1 if the actual response includes information that
+                is semantically similar to the expected text, even if the wording
+                is different. Also return 1 if the expected text is an
+                instruction or qualitative behavior and the response satisfies
+                it.
+
+                Return score 0 if the response omits, contradicts, or only
+                weakly implies the expected text or behavior.
+
+                Examples:
+                - Expected "30 x 30 resolution" matches responses that say
+                  "30-meter by 30-meter pixels" or "30 m resolution".
+                - Expected "clarifies to user that dataset isn't available"
+                  matches responses that explain the requested dataset is not
+                  available and ask the user to choose another option.
+
+                Return:
+                - score: 1 if the expected text/behavior is included, otherwise 0
+                """,
+            ),
+        ],
+    )
+
+    judge_chain = JUDGE_PROMPT | HAIKU.with_structured_output(TextMatchScore)
+    judgement = judge_chain.invoke(
+        {
+            "expected_text": expected_text,
+            "actual_answer": actual_answer,
+        },
+    )
+
+    return judgement.score

--- a/src/gnw_evals/evaluators/llm_judges.py
+++ b/src/gnw_evals/evaluators/llm_judges.py
@@ -65,6 +65,13 @@ def llm_judge_clarification(agent_state: dict, query: str) -> dict:
             - Asking to choose between options
             - Expressing uncertainty about what the user wants
 
+            Do NOT count the response as a clarification request if the agent directly answers the user's question
+            and only asks an optional follow-up question afterward, such as offering to analyze a specific region,
+            compare locations, or continue with a next step.
+
+            Only return true if the response primarily asks for more information before it can answer,
+            or says it cannot proceed because the original query is ambiguous.
+
             Return true if this is a clarification request, false if the agent attempted to complete the task.
             """,
             ),

--- a/src/gnw_evals/runners/base.py
+++ b/src/gnw_evals/runners/base.py
@@ -135,6 +135,7 @@ class BaseTestRunner(ABC):
         data_eval = evaluate_data_pull(
             agent_state,
             expected_clarification=expected_data.expected_clarification,
+            expected_answer=expected_data.expected_answer,
             query=query,
         )
         answer_eval = evaluate_final_answer(

--- a/src/gnw_evals/runners/base.py
+++ b/src/gnw_evals/runners/base.py
@@ -84,6 +84,7 @@ class BaseTestRunner(ABC):
             # Answer evaluation fields
             charts_answer_score=None,
             agent_answer_score=None,
+            expected_text_match_score=None,
             actual_charts_answer=None,
             actual_agent_answer=None,
             # Clarification evaluation fields
@@ -139,6 +140,7 @@ class BaseTestRunner(ABC):
         answer_eval = evaluate_final_answer(
             agent_state,
             expected_data.expected_answer,
+            expected_data.expected_text,
         )
 
         return {
@@ -193,6 +195,8 @@ class BaseTestRunner(ABC):
         if expected_data.expected_answer:
             scores.append(evaluations.get("charts_answer_score"))
             scores.append(evaluations.get("agent_answer_score"))
+        if expected_data.expected_text:
+            scores.append(evaluations.get("expected_text_match_score"))
 
         # Filter out None values (checks that weren't applicable)
         valid_scores = [s for s in scores if s is not None]

--- a/src/gnw_evals/utils/eval_types.py
+++ b/src/gnw_evals/utils/eval_types.py
@@ -13,6 +13,7 @@ class TestResult(BaseModel):
     thread_id: str
     trace_id: str | None = None
     trace_url: str | None = None
+    test_id: str = ""
     query: str
     eval_set: str = "custom"
     overall_score: float
@@ -95,6 +96,7 @@ class ExpectedData(BaseModel):
     expected_answer: str = ""
     expected_text: str = ""
     expected_clarification: bool | None = None
+    test_id: str = ""
     test_group: str = "unknown"
     status: str = "ready"
     thread_id: str | None = None

--- a/src/gnw_evals/utils/eval_types.py
+++ b/src/gnw_evals/utils/eval_types.py
@@ -48,6 +48,7 @@ class TestResult(BaseModel):
     # Answer evaluation fields
     charts_answer_score: float | None = None
     agent_answer_score: float | None = None
+    expected_text_match_score: float | None = None
     actual_charts_answer: str | None = None
     actual_agent_answer: str | None = None
 
@@ -65,6 +66,7 @@ class TestResult(BaseModel):
     expected_start_date: str = ""
     expected_end_date: str = ""
     expected_answer: str = ""
+    expected_text: str = ""
     expected_clarification: bool | None = None
     test_group: str = "unknown"
     status: str = "ready"
@@ -91,6 +93,7 @@ class ExpectedData(BaseModel):
     expected_start_date: str = ""
     expected_end_date: str = ""
     expected_answer: str = ""
+    expected_text: str = ""
     expected_clarification: bool | None = None
     test_group: str = "unknown"
     status: str = "ready"

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1118,6 +1118,48 @@ def test_answer_evaluator_no_charts_data():
         )
 
 
+def test_answer_evaluator_expected_text_match():
+    """Test that expected_text checks semantic inclusion in the agent response."""
+    from unittest.mock import patch
+
+    from gnw_evals.evaluators import evaluate_final_answer
+
+    agent_state = {
+        "charts_data": [],
+        "messages": [
+            type(
+                "obj",
+                (object,),
+                {
+                    "content": (
+                        "Tree cover loss is available at approximately "
+                        "30-meter by 30-meter pixel resolution."
+                    ),
+                },
+            )(),
+        ],
+    }
+
+    with patch(
+        "gnw_evals.evaluators.answer_evaluator.llm_judge_expected_text",
+    ) as mock_judge:
+        mock_judge.return_value = 1.0
+
+        result = evaluate_final_answer(
+            agent_state=agent_state,
+            expected_answer="",
+            expected_text="30 x 30 resolution",
+        )
+
+        assert result["charts_answer_score"] is None
+        assert result["agent_answer_score"] is None
+        assert result["expected_text_match_score"] == 1.0
+        mock_judge.assert_called_once_with(
+            "30 x 30 resolution",
+            agent_state["messages"][0].content,
+        )
+
+
 def test_overall_score_with_both_answer_scores():
     """Test that overall score calculation includes both answer scores.
 
@@ -1138,6 +1180,7 @@ def test_overall_score_with_both_answer_scores():
         "date_match_score": None,  # Not evaluated (missing expected)
         "charts_answer_score": 1.0,  # Charts answer correct
         "agent_answer_score": 0.0,  # Agent answer wrong
+        "expected_text_match_score": None,
         "clarification_requested_score": None,
     }
 
@@ -1157,6 +1200,34 @@ def test_overall_score_with_both_answer_scores():
     # = (1.0 + 1.0 + 1.0 + 1.0 + 0.0) / 5 = 0.8
     assert score == 0.8, (
         f"Expected 0.8, got {score}. Both answer scores should be included in average"
+    )
+
+
+def test_overall_score_with_expected_text_score():
+    """Test that expected_text_match_score is included in overall score."""
+    from gnw_evals.runners.api import APITestRunner
+    from gnw_evals.utils.eval_types import ExpectedData
+
+    runner = APITestRunner(api_base_url="http://test", api_token="test")
+
+    evaluations = {
+        "aoi_id_match_score": None,
+        "dataset_id_match_score": None,
+        "context_layer_match_score": None,
+        "data_pull_exists_score": None,
+        "date_match_score": None,
+        "charts_answer_score": None,
+        "agent_answer_score": None,
+        "expected_text_match_score": 1.0,
+        "clarification_requested_score": None,
+    }
+
+    expected_data = ExpectedData(expected_text="clarifies dataset is unavailable")
+
+    score = runner._calculate_overall_score(evaluations, expected_data)
+
+    assert score == 1.0, (
+        f"Expected 1.0, got {score}. Expected text score should be included"
     )
 
 

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -588,6 +588,7 @@ def test_data_pull_evaluator_missing_expected_dates():
     # Data pull evaluation (no longer includes dates)
     data_result = evaluate_data_pull(
         agent_state=agent_state,
+        expected_answer="Test",
         min_rows=1,
         query="",
     )
@@ -602,6 +603,30 @@ def test_data_pull_evaluator_missing_expected_dates():
     assert data_result["data_pull_exists_score"] == 1.0, "Data pull should succeed"
     assert date_result["date_match_score"] is None, (
         "Date score should be None when expected dates are missing"
+    )
+
+
+def test_data_pull_evaluator_missing_expected_answer():
+    """Test that data pull score is None when expected_answer is missing."""
+    from gnw_evals.evaluators import evaluate_data_pull
+
+    agent_state = {
+        "statistics": [
+            {
+                "data": {"value": [100, 200]},
+            },
+        ],
+    }
+
+    data_result = evaluate_data_pull(
+        agent_state=agent_state,
+        expected_answer="",
+        min_rows=1,
+        query="",
+    )
+
+    assert data_result["data_pull_exists_score"] is None, (
+        "Data pull score should be None when expected_answer is missing"
     )
 
 
@@ -776,6 +801,7 @@ def test_data_pull_evaluator_all_fields_present():
     # Data pull evaluation
     data_result = evaluate_data_pull(
         agent_state=agent_state,
+        expected_answer="Test",
         min_rows=1,
         query="",
     )

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -977,6 +977,19 @@ def test_clarification_evaluator_no_query():
     )
 
 
+def test_clarification_judge_allows_optional_follow_up_questions():
+    """Test that clarification prompt excludes answered metadata follow-ups."""
+    import inspect
+
+    from gnw_evals.evaluators.llm_judges import llm_judge_clarification
+
+    source = inspect.getsource(llm_judge_clarification)
+
+    assert "optional follow-up question" in source
+    assert "directly answers the user's question" in source
+    assert "before it can answer" in source
+
+
 def test_clarification_and_other_evaluations_run_together():
     """Integration test: clarification detection doesn't block other evaluations.
 


### PR DESCRIPTION
A simpler version of my PR, a handful of golden set tests were trying to test metadata/citation responses, and using the `expected_answer` field. `expected_answer` is really looking more for specific numbers, and so I created a new column/judge to specifically score subjective questions like "does it include X metadata or caution". I chose the write in approach because this seems to be the natural instinct of people writing these evals, and gives a broad field for evaluating text content, but we could also make more specific judges for metadata.

I also added exporting the test_id field just so it's easier to match results to the docs when doing cross comparison.