### PR TITLE
Update check for data pull

### DIFF
--- a/src/gnw_evals/evaluators/data_pull_evaluator.py
+++ b/src/gnw_evals/evaluators/data_pull_evaluator.py
@@ -37,7 +37,9 @@ def _data_pull_outcome(
 ) -> tuple[bool, int, str]:
     """Determine whether a data pull succeeded and how many rows are available."""
     source_url = (stat_entry.get("source_url") or "").strip()
-    if source_url:
+    id = stat_entry.get("id") or ""
+    print(f"source_url: {source_url}, id: {id}")
+    if source_url and id:
         return True, 1, ""
 
     row_count = _count_rows(stat_entry.get("data"))

--- a/src/gnw_evals/evaluators/data_pull_evaluator.py
+++ b/src/gnw_evals/evaluators/data_pull_evaluator.py
@@ -37,9 +37,8 @@ def _data_pull_outcome(
 ) -> tuple[bool, int, str]:
     """Determine whether a data pull succeeded and how many rows are available."""
     source_url = (stat_entry.get("source_url") or "").strip()
-    id = stat_entry.get("id") or ""
-    print(f"source_url: {source_url}, id: {id}")
-    if source_url and id:
+    pull_id = (stat_entry.get("id") or "").strip()
+    if source_url or pull_id:
         return True, 1, ""
 
     row_count = _count_rows(stat_entry.get("data"))

--- a/src/gnw_evals/evaluators/data_pull_evaluator.py
+++ b/src/gnw_evals/evaluators/data_pull_evaluator.py
@@ -5,6 +5,47 @@ from typing import Any
 from gnw_evals.evaluators.utils import normalize_end_date, normalize_start_date
 
 
+def _latest_statistics(agent_state: dict[str, Any]) -> dict[str, Any]:
+    """Return the most recent statistics entry from agent state."""
+    stats = agent_state.get("statistics")
+    if not stats:
+        return {}
+    if isinstance(stats, dict):
+        return stats
+    if isinstance(stats, list) and stats:
+        last = stats[-1]
+        return last if isinstance(last, dict) else {}
+    return {}
+
+
+def _count_rows(raw_data: Any) -> int:
+    """Count rows in legacy inline statistics data."""
+    if isinstance(raw_data, list):
+        return len(raw_data)
+    if isinstance(raw_data, dict):
+        if not raw_data:
+            return 0
+        lengths = [len(v) for v in raw_data.values() if isinstance(v, list)]
+        return max(lengths) if lengths else 0
+    return 0
+
+
+def _data_pull_outcome(
+    stat_entry: dict[str, Any],
+    *,
+    min_rows: int,
+) -> tuple[bool, int, str]:
+    """Determine whether a data pull succeeded and how many rows are available."""
+    source_url = (stat_entry.get("source_url") or "").strip()
+    if source_url:
+        return True, 1, ""
+
+    row_count = _count_rows(stat_entry.get("data"))
+    if row_count < min_rows:
+        return False, row_count, "insufficient rows of data retrieved"
+    return True, row_count, ""
+
+
 def evaluate_date_selection(
     agent_state: dict[str, Any],
     expected_start_date: str | None = None,
@@ -29,8 +70,12 @@ def evaluate_date_selection(
         - actual_end_date (str | None): Actual end date from agent state
 
     """
-    actual_start_date = agent_state.get("start_date", "")
-    actual_end_date = agent_state.get("end_date", "")
+    stat_entry = _latest_statistics(agent_state)
+    actual_start_date = agent_state.get("start_date") or stat_entry.get(
+        "start_date",
+        "",
+    )
+    actual_end_date = agent_state.get("end_date") or stat_entry.get("end_date", "")
 
     # If no expected dates, skip evaluation
     if not expected_start_date or not expected_end_date:
@@ -106,33 +151,28 @@ def evaluate_data_pull(
         agent_state: Final agent state after execution
         expected_clarification: Expected clarification behavior (True/False/None)
         expected_answer: Expected answer text. Data pull is only evaluated when provided.
-        min_rows: Minimum number of rows expected
+        min_rows: Minimum number of rows expected (legacy inline data only)
         query: Original user query (kept for compatibility but not used)
 
     Returns:
         Dict with:
-        - data_pull_exists_score (0/1/None): 1.0 if data pulled with sufficient rows,
-          0.0 if insufficient rows or no data, None if not applicable
-        - row_count (int): Number of rows in pulled data
-        - data_pull_success (bool): Whether data pull met minimum row requirement
+        - data_pull_exists_score (0/1/None): 1.0 if data pull succeeded,
+          0.0 if pull missing or failed, None if not applicable
+        - row_count (int): 1 when source_url is present, else legacy row count
+        - data_pull_success (bool): Whether data pull met success criteria
         - error (str): Error message if applicable
 
     """
-    stats = agent_state.get("statistics", [])
-    if stats:
-        raw_data = stats[-1].get("data", [])
-        error = ""
+    stat_entry = _latest_statistics(agent_state)
+    if stat_entry:
+        data_pull_success, row_count, error = _data_pull_outcome(
+            stat_entry,
+            min_rows=min_rows,
+        )
     else:
-        raw_data = []
-        error = "no data retrieved"
-
-    row_count = len(raw_data)
-
-    if row_count < min_rows:
         data_pull_success = False
-        error = "insufficient rows of data retrieved"
-    else:
-        data_pull_success = True
+        row_count = 0
+        error = "no data retrieved"
 
     # If we expect clarification or no answer check, data pull evaluation is not applicable.
     if expected_clarification is True or not expected_answer:
@@ -143,5 +183,6 @@ def evaluate_data_pull(
     return {
         "data_pull_exists_score": data_pull_exists_score,
         "row_count": row_count,
+        "data_pull_success": data_pull_success,
         "error": error,
     }

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -118,12 +118,11 @@ def mock_agent_state():
         },
         "statistics": [
             {
-                "data": {
-                    "date": ["2023-08-01", "2023-08-15", "2024-08-01"],
-                    "value": [100, 150, 80],
-                },
+                "dataset_name": "Global All Ecosystem Disturbance Alerts (DIST-ALERT)",
                 "start_date": "8/1/2023",
                 "end_date": "8/31/2024",
+                "source_url": "https://analytics.example/api/pull/abc123",
+                "data": {},
             },
         ],
         "start_date": "8/1/2023",
@@ -576,9 +575,10 @@ def test_data_pull_evaluator_missing_expected_dates():
     agent_state = {
         "statistics": [
             {
-                "data": {"value": [100, 200]},
                 "start_date": "2023-01-01",
                 "end_date": "2023-12-31",
+                "source_url": "https://analytics.example/api/pull/xyz",
+                "data": {},
             },
         ],
         "start_date": "2023-01-01",
@@ -613,7 +613,8 @@ def test_data_pull_evaluator_missing_expected_answer():
     agent_state = {
         "statistics": [
             {
-                "data": {"value": [100, 200]},
+                "source_url": "https://analytics.example/api/pull/xyz",
+                "data": {},
             },
         ],
     }
@@ -789,9 +790,10 @@ def test_data_pull_evaluator_all_fields_present():
     agent_state = {
         "statistics": [
             {
-                "data": {"value": [100, 200]},
                 "start_date": "2023-01-01",
                 "end_date": "2023-12-31",
+                "source_url": "https://analytics.example/api/pull/xyz",
+                "data": {},
             },
         ],
         "start_date": "2023-01-01",
@@ -1401,6 +1403,104 @@ def test_normalize_end_date_yyyy_format():
     # Other formats pass through standard normalization
     assert normalize_end_date("12/31/2023") == "2023-12-31"
     assert normalize_end_date("2023-12-31") == "2023-12-31"
+
+
+def test_data_pull_evaluator_source_url_with_empty_data():
+    """ID-backed pulls succeed when source_url is set even if data is empty."""
+    from gnw_evals.evaluators import evaluate_data_pull
+
+    agent_state = {
+        "statistics": {
+            "dataset_name": "DIST-ALERT",
+            "start_date": "8/1/2023",
+            "end_date": "8/31/2024",
+            "source_url": "https://analytics.example/api/pull/abc123",
+            "data": {},
+        },
+    }
+
+    result = evaluate_data_pull(
+        agent_state=agent_state,
+        expected_answer="Test",
+        min_rows=1,
+    )
+
+    assert result["data_pull_exists_score"] == 1.0
+    assert result["data_pull_success"] is True
+    assert result["row_count"] == 1
+    assert result["error"] == ""
+
+
+def test_data_pull_evaluator_empty_data_without_source_url_fails():
+    """Empty inline data without source_url counts as a failed pull."""
+    from gnw_evals.evaluators import evaluate_data_pull
+
+    agent_state = {
+        "statistics": [
+            {
+                "data": {},
+                "start_date": "2023-01-01",
+                "end_date": "2023-12-31",
+            },
+        ],
+    }
+
+    result = evaluate_data_pull(
+        agent_state=agent_state,
+        expected_answer="Test",
+        min_rows=1,
+    )
+
+    assert result["data_pull_exists_score"] == 0.0
+    assert result["data_pull_success"] is False
+    assert result["row_count"] == 0
+    assert "insufficient rows" in result["error"]
+
+
+def test_data_pull_evaluator_legacy_inline_data():
+    """Legacy statistics with inline column data still score by row count."""
+    from gnw_evals.evaluators import evaluate_data_pull
+
+    agent_state = {
+        "statistics": [
+            {
+                "data": {"value": [100, 200]},
+            },
+        ],
+    }
+
+    result = evaluate_data_pull(
+        agent_state=agent_state,
+        expected_answer="Test",
+        min_rows=1,
+    )
+
+    assert result["data_pull_exists_score"] == 1.0
+    assert result["data_pull_success"] is True
+    assert result["row_count"] == 2
+
+
+def test_date_selection_reads_dates_from_statistics():
+    """Date evaluation falls back to statistics when top-level dates are absent."""
+    from gnw_evals.evaluators import evaluate_date_selection
+
+    agent_state = {
+        "statistics": {
+            "start_date": "2023-01-01",
+            "end_date": "2023-12-31",
+            "source_url": "https://analytics.example/api/pull/abc123",
+            "data": {},
+        },
+    }
+
+    result = evaluate_date_selection(
+        agent_state=agent_state,
+        expected_start_date="1/1/2023",
+        expected_end_date="12/31/2023",
+    )
+
+    assert result["date_match_score"] == 1.0
+    assert result["date_success"] is True
 
 
 def test_evaluate_data_pull_with_date_format_mismatch():


### PR DESCRIPTION
Pull data statistics are no longer stored in state, they are stored in DB and an ID is created, and the source url is tracked.

This PR changes the lookup to make sure `sourc_url` and `id` for db store is created as well.


Refs

https://github.com/wri/project-zeno/pull/642

https://github.com/wri/project-zeno/pull/665