### PR TITLE
Add more metrics to evals run summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ SPREADSHEET_ID=<your-google-spreadsheet-id>
 # STATUS_FILTER. Skip values in 'status' column (comma-separated values). Default: "skip"
 # STATUS_FILTER=skip
 
+# Optional overrides for SIMPLE E2E TEST SUMMARY (otherwise fetched from /api/metadata)
+#GNW_CODE_VERSION=0.1.0
+#GNW_PROMPTS_VERSION=abc123
+
 # Other options
 #API_BASE_URL
 #TEST_FILE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ ignore = [
     "D104",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D103"]  # test functions don't need docstrings
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -142,7 +142,9 @@ async def run_csv_tests(config) -> list[TestResult]:
         run_timestamp=run_started_at,
         api_metadata=api_metadata,
         durations=[
-            r.duration_seconds for r in results if r.duration_seconds is not None
+            float(r.duration_seconds)
+            for r in results
+            if isinstance(r.duration_seconds, (int, float))
         ],
     )
     _print_csv_summary(results, summary_context)

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from datetime import UTC, datetime
 
 import click
 import dotenv
@@ -7,11 +8,13 @@ import dotenv
 from gnw_evals.data_handlers import CSVLoader, ResultExporter
 from gnw_evals.runners import APITestRunner
 from gnw_evals.utils.eval_types import ExpectedData, TestResult
-from gnw_evals.utils.sheet_registry import (
-    EVAL_SET_PRIMARY_METRIC,
-    EVAL_SETS,
-    get_sheet_url,
+from gnw_evals.utils.run_metadata import (
+    RunSummaryContext,
+    build_run_summary_context,
+    fetch_gnw_api_metadata,
+    print_run_summary_header,
 )
+from gnw_evals.utils.sheet_registry import EVAL_SETS, get_sheet_url
 
 dotenv.load_dotenv()
 
@@ -47,9 +50,10 @@ async def run_single_test(
         **{k: v for k, v in test_dict.items() if k != "query"},
     )
     result = await runner.run_test(test_case.query, expected_data)
+    duration = time.time() - start_time
+    result.duration_seconds = duration
 
     # Print completion with timing
-    duration = time.time() - start_time
     all_scores = [
         v
         for k, v in result.model_dump().items()
@@ -89,6 +93,9 @@ async def run_csv_tests(config) -> list[TestResult]:
         api_token=config.api_token,
     )
     print(f"Using API endpoint: {config.api_base_url}")
+
+    run_started_at = datetime.now(UTC)
+    api_metadata = await fetch_gnw_api_metadata(config.api_base_url)
 
     # Run tests in parallel
     start_time = time.time()
@@ -130,11 +137,22 @@ async def run_csv_tests(config) -> list[TestResult]:
     print(f"\nAll tests completed in {total_duration:.1f} seconds")
 
     # Print summary
-    _print_csv_summary(results)
+    summary_context = build_run_summary_context(
+        api_base_url=config.api_base_url,
+        run_timestamp=run_started_at,
+        api_metadata=api_metadata,
+        durations=[
+            r.duration_seconds for r in results if r.duration_seconds is not None
+        ],
+    )
+    _print_csv_summary(results, summary_context)
     return results
 
 
-def _print_csv_summary(results: list[TestResult]) -> None:
+def _print_csv_summary(
+    results: list[TestResult],
+    summary_context: RunSummaryContext | None = None,
+) -> None:
     """Print CSV test summary statistics."""
     total_tests = len(results)
     if total_tests == 0:
@@ -157,8 +175,10 @@ def _print_csv_summary(results: list[TestResult]) -> None:
         return f"{label_col:<{LABEL_WIDTH}} {0:>3} / {0:>3}"
 
     print(f"\n{'=' * 50}")
-    print("SIMPLE E2E TEST SUMMARY")
+    print("EVALUATION SUMMARY")
     print(f"{'=' * 50}")
+    if summary_context is not None:
+        print_run_summary_header(summary_context)
     print(f"Tests Run (after filters): {total_tests}")
     print()
 
@@ -395,35 +415,6 @@ def run_evals(
             offset=offset,
         )
         exporter.save_results_to_csv(all_results, final_output)
-
-        # Print summary
-        print(f"\n{'=' * 70}")
-        print("RESULTS SUMMARY")
-        print(f"{'=' * 70}")
-        print(f"Total tests: {len(all_results)}")
-
-        if len(eval_sets_to_run) > 1:
-            # Longest field name is "dataset_id_match_score" = 22 chars, +1 for colon
-            METRIC_COL_WIDTH = 23
-            print("\nBreakdown by eval set:")
-            for es in eval_sets_to_run:
-                es_results = [r for r in all_results if r.eval_set == es]
-                if not es_results:
-                    continue
-                metric_field = EVAL_SET_PRIMARY_METRIC.get(es, "agent_answer_score")
-                metric_label = f"{metric_field}:"
-                scores = [
-                    v
-                    for r in es_results
-                    if (v := getattr(r, metric_field, None)) is not None
-                ]
-                evaluated = len(scores)
-                passed = sum(1 for s in scores if s == 1.0)
-                if evaluated > 0:
-                    metric_str = f"{metric_label:<{METRIC_COL_WIDTH}} {passed:>3} / {evaluated:>3} ({passed / evaluated:.2f})"
-                else:
-                    metric_str = f"{metric_label:<{METRIC_COL_WIDTH}} {0:>3} / {0:>3}"
-                print(f"  {es:30} | Tests: {len(es_results):3} | {metric_str}")
     else:
         print("\n❌ No results collected from any eval set")
 

--- a/src/gnw_evals/data_handlers/result_exporter.py
+++ b/src/gnw_evals/data_handlers/result_exporter.py
@@ -61,6 +61,7 @@ class ResultExporter:
             "expected_text_match_score_reason",
             "clarification_requested_score",
             "execution_time",
+            "duration_seconds",
             "error",
             "trace_url",
         ]
@@ -87,6 +88,7 @@ class ResultExporter:
             "trace_url",
             "overall_score",
             "execution_time",
+            "duration_seconds",
             # AOI: Expected vs Actual
             "expected_aoi_ids",
             "actual_id",

--- a/src/gnw_evals/utils/eval_types.py
+++ b/src/gnw_evals/utils/eval_types.py
@@ -18,6 +18,7 @@ class TestResult(BaseModel):
     eval_set: str = "custom"
     overall_score: float
     execution_time: str
+    duration_seconds: float | None = None
 
     # AOI evaluation fields - separate binary scores (0/1/None)
     aoi_id_match_score: float | None = None

--- a/src/gnw_evals/utils/run_metadata.py
+++ b/src/gnw_evals/utils/run_metadata.py
@@ -1,0 +1,160 @@
+"""Helpers for eval run metadata shown in the E2E summary."""
+
+import os
+import statistics
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from gnw_evals.utils.models import HAIKU
+
+
+@dataclass(frozen=True)
+class LatencyStats:
+    """Per-test latency statistics in seconds."""
+
+    count: int
+    avg: float
+    std: float
+    min: float
+    max: float
+
+
+@dataclass(frozen=True)
+class RunSummaryContext:
+    """Metadata printed in the SIMPLE E2E TEST SUMMARY header."""
+
+    api_base_url: str
+    environment: str
+    run_timestamp: datetime
+    gnw_code_version: str
+    gnw_prompts_version: str
+    gnw_agent_llm: str
+    eval_judge_llm: str
+    latency: LatencyStats | None = None
+
+
+def infer_environment(api_base_url: str) -> str:
+    """Map API base URL to a short environment label."""
+    host = urlparse(api_base_url).netloc.lower()
+    if "staging" in host:
+        return "staging"
+    if (
+        host in {"localhost", "127.0.0.1"}
+        or host.startswith("localhost:")
+        or host.startswith("127.0.0.1:")
+    ):
+        return "localhost"
+    if "globalnaturewatch.org" in host:
+        return "prod"
+    return "custom"
+
+
+def get_eval_judge_llm_label() -> str:
+    """Return the LLM family and model used by eval judges in this repo."""
+    model = getattr(HAIKU, "model_name", None) or getattr(HAIKU, "model", "unknown")
+    return f"Anthropic / {model}"
+
+
+def _format_gnw_agent_llm(metadata: dict[str, Any] | None) -> str:
+    if not metadata:
+        return "unknown (metadata unavailable)"
+    model_info = metadata.get("model") or {}
+    current = model_info.get("current", "unknown")
+    model_class = model_info.get("model_class", "unknown")
+    small = model_info.get("small", "unknown")
+    small_class = model_info.get("small_model_class", "unknown")
+    return f"primary {current} ({model_class}), small {small} ({small_class})"
+
+
+def resolve_gnw_versions(metadata: dict[str, Any] | None) -> tuple[str, str]:
+    """Resolve GNW code and prompts versions from env vars or API metadata."""
+    code_version = os.getenv("GNW_CODE_VERSION")
+    if not code_version and metadata:
+        code_version = metadata.get("version")
+    if not code_version:
+        code_version = "unknown"
+
+    prompts_version = os.getenv("GNW_PROMPTS_VERSION")
+    if not prompts_version:
+        prompts_version = "unknown"
+
+    return code_version, prompts_version
+
+
+async def fetch_gnw_api_metadata(api_base_url: str) -> dict[str, Any] | None:
+    """Fetch public /api/metadata from the GNW API."""
+    url = f"{api_base_url.rstrip('/')}/api/metadata"
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.json()
+    except Exception as exc:
+        print(f"Warning: could not fetch GNW API metadata from {url}: {exc}")
+        return None
+
+
+def compute_latency_stats(durations: list[float]) -> LatencyStats | None:
+    """Compute latency statistics from per-test durations in seconds."""
+    if not durations:
+        return None
+    return LatencyStats(
+        count=len(durations),
+        avg=statistics.mean(durations),
+        std=statistics.stdev(durations) if len(durations) > 1 else 0.0,
+        min=min(durations),
+        max=max(durations),
+    )
+
+
+def build_run_summary_context(
+    api_base_url: str,
+    run_timestamp: datetime,
+    api_metadata: dict[str, Any] | None,
+    durations: list[float],
+) -> RunSummaryContext:
+    """Build summary context from API metadata, env overrides, and latencies."""
+    code_version, prompts_version = resolve_gnw_versions(api_metadata)
+    return RunSummaryContext(
+        api_base_url=api_base_url,
+        environment=infer_environment(api_base_url),
+        run_timestamp=run_timestamp,
+        gnw_code_version=code_version,
+        gnw_prompts_version=prompts_version,
+        gnw_agent_llm=_format_gnw_agent_llm(api_metadata),
+        eval_judge_llm=get_eval_judge_llm_label(),
+        latency=compute_latency_stats(durations),
+    )
+
+
+def format_run_timestamp(run_timestamp: datetime) -> str:
+    """Format run timestamp for console output."""
+    if run_timestamp.tzinfo is None:
+        run_timestamp = run_timestamp.replace(tzinfo=UTC)
+    return run_timestamp.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def print_run_summary_header(context: RunSummaryContext) -> None:
+    """Print run metadata block before metric lines."""
+    print(f"Environment:           {context.environment}")
+    print(f"API Base URL:          {context.api_base_url}")
+    print(f"Run timestamp:         {format_run_timestamp(context.run_timestamp)}")
+    print(f"GNW code version:      {context.gnw_code_version}")
+    print(f"GNW prompts version:   {context.gnw_prompts_version}")
+    print(f"GNW agent LLM:         {context.gnw_agent_llm}")
+    print(f"Eval judge LLM:        {context.eval_judge_llm}")
+    if context.latency:
+        latency = context.latency
+        print(
+            "Test latency (s):      "
+            f"avg={latency.avg:.1f}, std={latency.std:.1f}, "
+            f"min={latency.min:.1f}, max={latency.max:.1f} "
+            f"(n={latency.count})",
+        )
+    else:
+        print("Test latency (s):      n/a")
+    print()

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -366,14 +366,18 @@ async def test_run_csv_tests_caps_workers_to_five_and_sample_size(mock_config):
 
         with patch("gnw_evals.core.APITestRunner"):
             with patch("gnw_evals.core._print_csv_summary"):
-                with patch("gnw_evals.core.asyncio.Semaphore") as mock_semaphore:
-                    with patch(
-                        "gnw_evals.core.run_single_test",
-                        new=AsyncMock(return_value=MagicMock()),
-                    ):
-                        await run_csv_tests(mock_config)
+                with patch(
+                    "gnw_evals.core.fetch_gnw_api_metadata",
+                    new=AsyncMock(return_value=None),
+                ):
+                    with patch("gnw_evals.core.asyncio.Semaphore") as mock_semaphore:
+                        with patch(
+                            "gnw_evals.core.run_single_test",
+                            new=AsyncMock(return_value=MagicMock()),
+                        ):
+                            await run_csv_tests(mock_config)
 
-                        mock_semaphore.assert_called_once_with(2)
+                            mock_semaphore.assert_called_once_with(2)
 
 
 @pytest.mark.asyncio
@@ -397,29 +401,35 @@ async def test_run_csv_tests_with_api_error(mock_test_cases, mock_config):
         )
 
         with patch("gnw_evals.runners.api.httpx.AsyncClient", return_value=mock_client):
-            with patch("gnw_evals.core.ResultExporter") as mock_exporter_class:
-                with patch(
-                    "gnw_evals.evaluators.answer_evaluator.llm_judge",
-                    return_value=1.0,
-                ):
+            with patch(
+                "gnw_evals.core.fetch_gnw_api_metadata",
+                new=AsyncMock(return_value=None),
+            ):
+                with patch("gnw_evals.core.ResultExporter") as mock_exporter_class:
                     with patch(
-                        "gnw_evals.evaluators.clarification_evaluator.llm_judge_clarification",
-                        return_value={"is_clarification": False, "explanation": ""},
+                        "gnw_evals.evaluators.answer_evaluator.llm_judge",
+                        return_value=1.0,
                     ):
-                        mock_exporter = MagicMock()
-                        mock_exporter_class.return_value = mock_exporter
+                        with patch(
+                            "gnw_evals.evaluators.clarification_evaluator.llm_judge_clarification",
+                            return_value={"is_clarification": False, "explanation": ""},
+                        ):
+                            mock_exporter = MagicMock()
+                            mock_exporter_class.return_value = mock_exporter
 
-                        # Run the tests - should handle error gracefully
-                        results = await run_csv_tests(mock_config)
+                            # Run the tests - should handle error gracefully
+                            results = await run_csv_tests(mock_config)
 
-                        # Should still return a result, but with error
-                        assert len(results) == 1, (
-                            "Should return 1 test result even on error"
-                        )
-                        assert results[0].overall_score == 0.0, (
-                            "Error should result in 0 score"
-                        )
-                        assert results[0].error is not None, "Error should be recorded"
+                            # Should still return a result, but with error
+                            assert len(results) == 1, (
+                                "Should return 1 test result even on error"
+                            )
+                            assert results[0].overall_score == 0.0, (
+                                "Error should result in 0 score"
+                            )
+                            assert results[0].error is not None, (
+                                "Error should be recorded"
+                            )
 
 
 @pytest.mark.asyncio

--- a/tests/test_run_metadata.py
+++ b/tests/test_run_metadata.py
@@ -1,0 +1,109 @@
+"""Unit tests for eval run metadata helpers."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from gnw_evals.utils.run_metadata import (
+    build_run_summary_context,
+    compute_latency_stats,
+    format_run_timestamp,
+    get_eval_judge_llm_label,
+    infer_environment,
+    print_run_summary_header,
+    resolve_gnw_versions,
+)
+
+
+@pytest.mark.parametrize(
+    ("api_base_url", "expected"),
+    [
+        ("https://api.staging.globalnaturewatch.org", "staging"),
+        ("https://api.globalnaturewatch.org", "prod"),
+        ("http://localhost:8000", "localhost"),
+        ("http://127.0.0.1:8000", "localhost"),
+        ("https://custom.example.com", "custom"),
+    ],
+)
+def test_infer_environment(api_base_url: str, expected: str) -> None:
+    assert infer_environment(api_base_url) == expected
+
+
+def test_resolve_gnw_versions_prefers_env_over_metadata(monkeypatch) -> None:
+    monkeypatch.setenv("GNW_CODE_VERSION", "code-1.2.3")
+    monkeypatch.setenv("GNW_PROMPTS_VERSION", "prompts-4.5.6")
+    code, prompts = resolve_gnw_versions({"version": "0.1.0"})
+    assert code == "code-1.2.3"
+    assert prompts == "prompts-4.5.6"
+
+
+def test_resolve_gnw_versions_uses_metadata_when_env_missing(monkeypatch) -> None:
+    monkeypatch.delenv("GNW_CODE_VERSION", raising=False)
+    monkeypatch.delenv("GNW_PROMPTS_VERSION", raising=False)
+    code, prompts = resolve_gnw_versions({"version": "0.9.0"})
+    assert code == "0.9.0"
+    assert prompts == "unknown"
+
+
+def test_compute_latency_stats() -> None:
+    stats = compute_latency_stats([10.0, 20.0, 30.0])
+    assert stats is not None
+    assert stats.count == 3
+    assert stats.avg == 20.0
+    assert stats.min == 10.0
+    assert stats.max == 30.0
+    assert stats.std == pytest.approx(10.0)
+
+
+def test_compute_latency_stats_single_value_has_zero_std() -> None:
+    stats = compute_latency_stats([42.5])
+    assert stats is not None
+    assert stats.std == 0.0
+
+
+def test_build_run_summary_context_formats_agent_llm() -> None:
+    context = build_run_summary_context(
+        api_base_url="https://api.staging.globalnaturewatch.org",
+        run_timestamp=datetime(2026, 5, 18, 12, 0, 0, tzinfo=UTC),
+        api_metadata={
+            "version": "0.1.0",
+            "model": {
+                "current": "gemini",
+                "model_class": "ChatGoogleGenerativeAI",
+                "small": "gemini-flash",
+                "small_model_class": "ChatGoogleGenerativeAI",
+            },
+        },
+        durations=[100.0, 200.0],
+    )
+    assert context.environment == "staging"
+    assert context.gnw_code_version == "0.1.0"
+    assert "gemini" in context.gnw_agent_llm
+    assert context.latency is not None
+    assert context.latency.avg == 150.0
+
+
+def test_get_eval_judge_llm_label_contains_anthropic() -> None:
+    assert "Anthropic" in get_eval_judge_llm_label()
+
+
+def test_format_run_timestamp_uses_utc() -> None:
+    assert format_run_timestamp(datetime(2026, 5, 18, 12, 30, 45, tzinfo=UTC)) == (
+        "2026-05-18 12:30:45 UTC"
+    )
+
+
+def test_print_run_summary_header(capsys) -> None:
+    context = build_run_summary_context(
+        api_base_url="https://api.staging.globalnaturewatch.org",
+        run_timestamp=datetime(2026, 5, 18, 12, 0, 0, tzinfo=UTC),
+        api_metadata={"version": "0.1.0", "model": {}},
+        durations=[12.3],
+    )
+    print_run_summary_header(context)
+    output = capsys.readouterr().out
+    assert "Environment:" in output
+    assert "staging" in output
+    assert "GNW code version:" in output
+    assert "Eval judge LLM:" in output
+    assert "Test latency (s):" in output


### PR DESCRIPTION
Adds more metadata like timestamps, urls, versions, models used. Also adds latency stats.

New summary looks like

```
==================================================
EVALUATION SUMMARY
==================================================
Environment:           staging
API Base URL:          https://api.staging.globalnaturewatch.org
Run timestamp:         2026-05-18 11:37:56 UTC
GNW code version:      0.1.0
GNW prompts version:   unknown
GNW agent LLM:         primary gemini-flash (ChatGoogleGenerativeAI), small gemini-flash (ChatGoogleGenerativeAI)
Eval judge LLM:        Anthropic / claude-haiku-4-5
Test latency (s):      avg=88.4, std=25.5, min=67.5, max=131.0 (n=5)

Tests Run (after filters): 5

Agent Answer:               4 /   4 (1.00)

AOI ID Match:               4 /   4 (1.00)
Dataset ID Match:           5 /   5 (1.00)
Dataset Parameter Match:    0 /   0
Context Layer Match:        2 /   2 (1.00)
Data Pull Exists:           4 /   4 (1.00)
Date Match:                 5 /   5 (1.00)
Charts Answer:              3 /   4 (0.75)
Expected Text Match:        0 /   0
Clarification Requested:    0 /   0

(warning: overall_score is experimental and untested)
Tests with overall score ≥0.7:    5 /   5 (100.0%)

Summary results saved to: localhost_20260518_124007_summary.csv
Detailed results saved to: localhost_20260518_124007_detailed.csv
```



Closes #9
