### PR TITLE
Improve progress logging

### DIFF
--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -18,6 +18,71 @@ from gnw_evals.utils.sheet_registry import EVAL_SETS, get_sheet_url
 
 dotenv.load_dotenv()
 
+_OVERALL_SCORE_FIELD = "overall_score"
+
+
+def _check_scores_from_result(result: TestResult) -> list[tuple[str, float]]:
+    """Return (field_name, score) pairs for per-check metrics on a result."""
+    return [
+        (field, value)
+        for field, value in result.model_dump().items()
+        if field.endswith("_score")
+        and field != _OVERALL_SCORE_FIELD
+        and value is not None
+    ]
+
+
+def _all_checks_passed(result: TestResult) -> bool:
+    """Return whether every evaluated check scored 1.0 and the run had no error."""
+    if result.error:
+        return False
+    scores = _check_scores_from_result(result)
+    if not scores:
+        return True
+    return all(score == 1.0 for _, score in scores)
+
+
+def _test_display_id(test_case, test_index: int) -> str:
+    """Prefer CSV test_id; fall back to 1-based index."""
+    test_id = getattr(test_case, "test_id", None) or ""
+    if test_id:
+        return test_id
+    return f"#{test_index + 1}"
+
+
+def _print_pass_progress() -> None:
+    print(".", end="", flush=True)
+
+
+def _print_failure_details(
+    test_case,
+    test_index: int,
+    total_tests: int,
+    result: TestResult,
+    duration: float,
+) -> None:
+    """Print multi-line details for tests that did not pass all checks."""
+    scores = _check_scores_from_result(result)
+    checks_passed = sum(1 for _, score in scores if score == 1.0)
+    checks_total = len(scores)
+    test_id = _test_display_id(test_case, test_index)
+    query = getattr(test_case, "query", "") or result.query
+
+    print()
+    print(
+        f"[FAIL] {test_id} ({test_index + 1}/{total_tests}): "
+        f"{checks_passed}/{checks_total} checks passed ({duration:.1f}s)",
+    )
+    if query:
+        print(f"  query: {query[:120]}{'...' if len(query) > 120 else ''}")
+    if result.error:
+        print(f"  error: {result.error}")
+
+    failed_checks = [(name, score) for name, score in scores if score != 1.0]
+    for name, score in failed_checks:
+        label = name.removesuffix("_score").replace("_", " ")
+        print(f"  {label}: {score}")
+
 
 def _build_default_output_filename(
     eval_set: str,
@@ -42,7 +107,6 @@ async def run_single_test(
 ) -> TestResult:
     """Run a single test case."""
     start_time = time.time()
-    print(f"[STARTED]   Test {test_index + 1}/{total_tests}: {test_case.query[:60]}...")
 
     # Convert test case to ExpectedData (remove query field)
     test_dict = test_case.model_dump()
@@ -53,17 +117,10 @@ async def run_single_test(
     duration = time.time() - start_time
     result.duration_seconds = duration
 
-    # Print completion with timing
-    all_scores = [
-        v
-        for k, v in result.model_dump().items()
-        if k.endswith("_score") and k != "overall_score" and v is not None
-    ]
-    checks_passed = sum(1 for s in all_scores if s == 1.0)
-    checks_total = len(all_scores)
-    print(
-        f"[COMPLETED] Test {test_index + 1}/{total_tests}: {checks_passed} out of {checks_total} checks passed ({duration:.1f}s)",
-    )
+    if _all_checks_passed(result):
+        _print_pass_progress()
+    else:
+        _print_failure_details(test_case, test_index, total_tests, result, duration)
 
     return result
 
@@ -134,7 +191,8 @@ async def run_csv_tests(config) -> list[TestResult]:
         results = await asyncio.gather(*tasks)
 
     total_duration = time.time() - start_time
-    print(f"\nAll tests completed in {total_duration:.1f} seconds")
+    print()
+    print(f"All tests completed in {total_duration:.1f} seconds")
 
     # Print summary
     summary_context = build_run_summary_context(

--- a/tests/test_run_progress.py
+++ b/tests/test_run_progress.py
@@ -1,0 +1,68 @@
+"""Tests for CLI progress output during eval runs."""
+
+from gnw_evals.core import (
+    _all_checks_passed,
+    _print_failure_details,
+    _print_pass_progress,
+    _test_display_id,
+)
+from gnw_evals.utils.eval_types import ExpectedData, TestResult
+
+
+def _minimal_result(**kwargs) -> TestResult:
+    defaults = {
+        "thread_id": "t1",
+        "query": "test query",
+        "overall_score": 1.0,
+        "execution_time": "2026-01-01T00:00:00",
+    }
+    defaults.update(kwargs)
+    return TestResult(**defaults)
+
+
+def test_all_checks_passed_when_all_scores_are_one() -> None:
+    result = _minimal_result(
+        agent_answer_score=1.0,
+        aoi_id_match_score=1.0,
+    )
+    assert _all_checks_passed(result) is True
+
+
+def test_all_checks_passed_false_when_any_score_below_one() -> None:
+    result = _minimal_result(
+        agent_answer_score=1.0,
+        aoi_id_match_score=0.0,
+    )
+    assert _all_checks_passed(result) is False
+
+
+def test_all_checks_passed_false_on_error() -> None:
+    result = _minimal_result(error="API timeout")
+    assert _all_checks_passed(result) is False
+
+
+def test_test_display_id_prefers_test_id() -> None:
+    case = ExpectedData(test_id="1-042")
+    assert _test_display_id(case, 0) == "1-042"
+
+
+def test_test_display_id_falls_back_to_index() -> None:
+    case = ExpectedData()
+    assert _test_display_id(case, 4) == "#5"
+
+
+def test_print_pass_progress_writes_dot(capsys) -> None:
+    _print_pass_progress()
+    _print_pass_progress()
+    assert capsys.readouterr().out == ".."
+
+
+def test_print_failure_details_includes_test_id(capsys) -> None:
+    case = ExpectedData(test_id="1-001", query="What is the area?")
+    result = _minimal_result(agent_answer_score=0.0)
+    _print_failure_details(case, 0, 10, result, 12.3)
+    output = capsys.readouterr().out
+    assert "[FAIL] 1-001" in output
+    assert "0/1 checks passed" in output
+    assert "agent answer: 0.0" in output
+    assert "query: What is the area?" in output


### PR DESCRIPTION
Progress now prints only a `.` for successful queries with no failed checks. For the others it prints the ID, the query and the failed checks like so

```
[FAIL] 1-007 (5/58): 6/7 checks passed (38.7s)
  query: What percentage of disturbances in Occitanie (FRA) were due to Crop management in September 2024?
  charts answer: 0.0
......
[FAIL] 1-014 (10/58): 4/5 checks passed (46.0s)
  query: Which had more cropland area in 2024, Nigeria or Ghana?
  charts answer: 0.0
.....
[FAIL] 1-017 (13/58): 4/6 checks passed (80.6s)
  query: In Purbalingga, Indonesia what was the largest single land cover transition from 2015 to 2024?
  charts answer: 0.0
  agent answer: 0.0
........
[FAIL] 1-031 (25/58): 3/4 checks passed (35.3s)
  query: Which state has the most mangroves in Senegal: Fatick or Ziguinchor?
  dataset id match: 0.0
...Error: 
...
```