### PR TITLE
Add test_id filtering for targeted eval runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ uv run gnw_evals --api-token your_token --test-group-filter rel-accuracy
 # Filter by status (comma-separated)
 uv run gnw_evals --api-token your_token --status-filter ready,rerun
 
+# Run one specific test by test_id
+uv run gnw_evals --api-token your_token --test-id GOLD-001
+
 ```
 
 The framework supports multiple specialized eval sets, not just the GOLDEN SET

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -136,6 +136,7 @@ async def run_csv_tests(config) -> list[TestResult]:
         config.sample_size,
         config.test_group_filter,
         config.status_filter,
+        config.test_id_filter,
         config.random_seed,
         config.offset,
     )
@@ -362,6 +363,12 @@ def _print_csv_summary(
     help="Filter by status column (comma-separated values) (can also be set via STATUS_FILTER env var)",
 )
 @click.option(
+    "--test-id",
+    default=None,
+    envvar="TEST_ID",
+    help="Run only the test with this exact test_id (case-insensitive) (can also be set via TEST_ID env var)",
+)
+@click.option(
     "--output-filename",
     default=None,
     envvar="OUTPUT_FILENAME",
@@ -396,6 +403,7 @@ def run_evals(
     test_file: str | None,
     test_group_filter: str | None,
     status_filter: str | None,
+    test_id: str | None,
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
@@ -424,6 +432,7 @@ def run_evals(
             test_file=test_file,
             test_group_filter=test_group_filter,
             status_filter=status_filter,
+            test_id=test_id,
             output_filename=output_filename,
             num_workers=num_workers,
             random_seed=random_seed,
@@ -453,6 +462,7 @@ def run_evals(
             test_file=None,
             test_group_filter=test_group_filter,
             status_filter=status_filter,
+            test_id=test_id,
             output_filename=None,
             num_workers=num_workers,
             random_seed=random_seed,
@@ -486,6 +496,7 @@ def _run_custom_test_file(
     test_file: str,
     test_group_filter: str | None,
     status_filter: str | None,
+    test_id: str | None,
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
@@ -506,6 +517,7 @@ def _run_custom_test_file(
         test_file=test_file,
         test_group_filter=test_group_filter,
         status_filter=status_filter,
+        test_id=test_id,
         output_filename=None,
         num_workers=num_workers,
         random_seed=random_seed,
@@ -539,6 +551,7 @@ def _run_single_eval_set(
     test_file: str | None,
     test_group_filter: str | None,
     status_filter: str | None,
+    test_id: str | None,
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
@@ -571,6 +584,7 @@ EVALUATION CONFIGURATION
   Sample Size:       {sample_size}
   Test Group Filter: {test_group_filter or "None"}
   Status Filter:     {status_filter or "None"}
+  Test ID Filter:    {test_id or "None"}
   Output Filename:   {output_filename or "Auto-generated"}
   Num Workers:       {num_workers}
   Random Seed:       {random_seed}
@@ -599,6 +613,7 @@ EVALUATION CONFIGURATION
             self.test_file = resolved_test_file
             self.test_group_filter = test_group_filter
             self.status_filter = status_filter_list
+            self.test_id_filter = test_id
             self.output_filename = output_filename
             self.num_workers = num_workers
             self.random_seed = random_seed

--- a/src/gnw_evals/data_handlers/csv_loader.py
+++ b/src/gnw_evals/data_handlers/csv_loader.py
@@ -16,6 +16,7 @@ class CSVLoader:
         sample_size: int = 0,
         test_group_filter: str | None = None,
         status_filter: list[str] | None = None,
+        test_id_filter: str | None = None,
         random_seed: int = 42,
         offset: int = 0,
     ) -> list[ExpectedData]:
@@ -26,6 +27,7 @@ class CSVLoader:
             sample_size: Number of test cases to load (0 means all)
             test_group_filter: Filter by test_group column (optional)
             status_filter: List of status values to skip (case-insensitive, optional)
+            test_id_filter: Filter by exact test_id value (case-insensitive, optional)
             random_seed: Random seed for sampling (optional)
             offset: Offset for sampling (optional)
 
@@ -112,6 +114,16 @@ class CSVLoader:
                 print(
                     f"Filtered {original_count - filtered_count} tests based on test_group filter '{test_group_filter}'",
                 )
+
+        # Filter by test_id if specified
+        if test_id_filter:
+            original_count = len(df)
+            normalized_test_id_filter = test_id_filter.strip().lower()
+            df = df[df["test_id"].str.lower() == normalized_test_id_filter]
+            filtered_count = len(df)
+            print(
+                f"Filtered {original_count - filtered_count} tests based on test_id '{test_id_filter}'",
+            )
 
         # Sample if requested (-1 means run all rows, 0+ means run that many)
         if sample_size > 0 and sample_size < len(df):

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -146,6 +146,7 @@ class TestConfig:
     test_file: str = "gnw-eval-sets-gold.csv"
     test_group_filter: str | None = None
     status_filter: list[str] | None = None
+    test_id_filter: str | None = None
     output_filename: str = "test_results.csv"
     num_workers: int = 1
     random_seed: int = 0
@@ -282,6 +283,7 @@ async def test_run_csv_tests_with_mocked_data(
                             mock_config.sample_size,
                             mock_config.test_group_filter,
                             mock_config.status_filter,
+                            mock_config.test_id_filter,
                             mock_config.random_seed,
                             mock_config.offset,
                         )
@@ -1682,6 +1684,45 @@ def test_status_filter_none_keeps_all_rows(tmp_path):
     results = CSVLoader.load_test_data(str(csv_file), status_filter=None)
 
     assert len(results) == 4, "All rows should be kept when status_filter is None"
+
+
+def test_test_id_filter_matches_single_row(tmp_path):
+    """Test that test_id_filter keeps only the matching row."""
+    import pandas as pd
+
+    from gnw_evals.data_handlers.csv_loader import CSVLoader
+
+    csv_file = tmp_path / "test.csv"
+    pd.DataFrame(
+        {
+            "test_id": ["GOLD-001", "GOLD-002", "GOLD-003"],
+            "query": ["q1", "q2", "q3"],
+        },
+    ).to_csv(csv_file, index=False)
+
+    results = CSVLoader.load_test_data(str(csv_file), test_id_filter="gold-002")
+
+    assert len(results) == 1
+    assert results[0].test_id == "GOLD-002"
+    assert results[0].query == "q2"
+
+
+def test_test_id_filter_no_test_id_column_returns_no_rows(tmp_path):
+    """test_id_filter should return no rows when CSV has no test_id column."""
+    import pandas as pd
+
+    from gnw_evals.data_handlers.csv_loader import CSVLoader
+
+    csv_file = tmp_path / "test.csv"
+    pd.DataFrame(
+        {
+            "query": ["q1", "q2"],
+        },
+    ).to_csv(csv_file, index=False)
+
+    results = CSVLoader.load_test_data(str(csv_file), test_id_filter="gold-001")
+
+    assert len(results) == 0
 
 
 def test_default_output_filename_builder_for_single_eval_set():


### PR DESCRIPTION
This introduces a dedicated CLI/env option to run exactly one test row by ID so reruns and debugging are faster without changing datasets.

### How to test it

```bash
uv run gnw_evals --test-id 1-018
```