### PR TITLE
Feat/prepend proactive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ uv run gnw_evals --api-token your_token --status-filter ready,rerun
 # Print per-test results to screen instead of writing CSV files
 uv run gnw_evals --api-token your_token --print-results
 
+# Optionally prepend proactive guidance in front of every test query
+uv run gnw_evals --api-token your_token --prepend-proactive-flag
+
 ```
 
 The framework supports multiple specialized eval sets, not just the GOLDEN SET

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ uv run gnw_evals --api-token your_token --test-group-filter rel-accuracy
 # Filter by status (comma-separated)
 uv run gnw_evals --api-token your_token --status-filter ready,rerun
 
+# Print per-test results to screen instead of writing CSV files
+uv run gnw_evals --api-token your_token --print-results
+
 ```
 
 The framework supports multiple specialized eval sets, not just the GOLDEN SET

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -78,6 +78,10 @@ def _print_failure_details(
         print(f"  query: {query[:120]}{'...' if len(query) > 120 else ''}")
     if result.error:
         print(f"  error: {result.error}")
+    if result.app_thread_url:
+        print(f"  app thread: {result.app_thread_url}")
+    if result.trace_url:
+        print(f"  langfuse: {result.trace_url}")
 
     failed_checks = [(name, score) for name, score in scores if score != 1.0]
     for name, score in failed_checks:

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from datetime import UTC, datetime
 
@@ -97,6 +98,33 @@ def _build_default_output_filename(
         f"_workers_{num_workers}"
         f"_offset_{offset}"
     )
+
+
+def _print_results_to_screen(results: list[TestResult]) -> None:
+    """Print detailed per-test results to stdout as JSON."""
+    print(f"\nPrinting {len(results)} test result(s):")
+    for i, result in enumerate(results, 1):
+        print(f"\n--- Result {i}/{len(results)} ---")
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+
+
+def _save_or_print_results(
+    results: list[TestResult],
+    *,
+    print_results: bool,
+    output_filename: str | None,
+    default_output_filename: str,
+) -> None:
+    """Print results to screen or write CSV files. No-op when there are no results."""
+    if not results:
+        return
+
+    if print_results:
+        _print_results_to_screen(results)
+        return
+
+    exporter = ResultExporter()
+    exporter.save_results_to_csv(results, output_filename or default_output_filename)
 
 
 async def run_single_test(
@@ -362,6 +390,12 @@ def _print_csv_summary(
     help="Filter by status column (comma-separated values) (can also be set via STATUS_FILTER env var)",
 )
 @click.option(
+    "--print-results",
+    is_flag=True,
+    default=False,
+    help="Print detailed per-test results to screen instead of writing CSV files",
+)
+@click.option(
     "--output-filename",
     default=None,
     envvar="OUTPUT_FILENAME",
@@ -396,6 +430,7 @@ def run_evals(
     test_file: str | None,
     test_group_filter: str | None,
     status_filter: str | None,
+    print_results: bool,
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
@@ -424,6 +459,7 @@ def run_evals(
             test_file=test_file,
             test_group_filter=test_group_filter,
             status_filter=status_filter,
+            print_results=print_results,
             output_filename=output_filename,
             num_workers=num_workers,
             random_seed=random_seed,
@@ -453,6 +489,7 @@ def run_evals(
             test_file=None,
             test_group_filter=test_group_filter,
             status_filter=status_filter,
+            print_results=print_results,
             output_filename=None,
             num_workers=num_workers,
             random_seed=random_seed,
@@ -465,18 +502,17 @@ def run_evals(
                 result.eval_set = current_eval_set
             all_results.extend(results)
 
-    # Write combined CSV
-    if all_results:
-        exporter = ResultExporter()
-        final_output = output_filename or _build_default_output_filename(
+    _save_or_print_results(
+        all_results,
+        print_results=print_results,
+        output_filename=output_filename,
+        default_output_filename=_build_default_output_filename(
             eval_set=eval_set,
             sample_size=sample_size,
             num_workers=num_workers,
             offset=offset,
-        )
-        exporter.save_results_to_csv(all_results, final_output)
-    else:
-        print("\n❌ No results collected from any eval set")
+        ),
+    )
 
 
 def _run_custom_test_file(
@@ -486,6 +522,7 @@ def _run_custom_test_file(
     test_file: str,
     test_group_filter: str | None,
     status_filter: str | None,
+    print_results: bool,
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
@@ -506,6 +543,7 @@ def _run_custom_test_file(
         test_file=test_file,
         test_group_filter=test_group_filter,
         status_filter=status_filter,
+        print_results=print_results,
         output_filename=None,
         num_workers=num_workers,
         random_seed=random_seed,
@@ -516,19 +554,19 @@ def _run_custom_test_file(
     for result in results:
         result.eval_set = "custom"
 
-    # Write CSV
-    if results:
-        exporter = ResultExporter()
-        final_output = output_filename or _build_default_output_filename(
+    _save_or_print_results(
+        results,
+        print_results=print_results,
+        output_filename=output_filename,
+        default_output_filename=_build_default_output_filename(
             eval_set="custom",
             sample_size=sample_size,
             num_workers=num_workers,
             offset=offset,
-        )
-        exporter.save_results_to_csv(results, final_output)
+        ),
+    )
+    if results and not print_results:
         print(f"\n✓ Results saved: {len(results)} tests")
-    else:
-        print("\n❌ No results collected")
 
 
 def _run_single_eval_set(
@@ -539,6 +577,7 @@ def _run_single_eval_set(
     test_file: str | None,
     test_group_filter: str | None,
     status_filter: str | None,
+    print_results: bool,
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
@@ -571,6 +610,7 @@ EVALUATION CONFIGURATION
   Sample Size:       {sample_size}
   Test Group Filter: {test_group_filter or "None"}
   Status Filter:     {status_filter or "None"}
+  Print Results:     {print_results}
   Output Filename:   {output_filename or "Auto-generated"}
   Num Workers:       {num_workers}
   Random Seed:       {random_seed}

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import time
 from datetime import UTC, datetime
 
@@ -9,6 +8,7 @@ import dotenv
 from gnw_evals.data_handlers import CSVLoader, ResultExporter
 from gnw_evals.runners import APITestRunner
 from gnw_evals.utils.eval_types import ExpectedData, TestResult
+from gnw_evals.utils.result_display import print_results_to_screen
 from gnw_evals.utils.run_metadata import (
     RunSummaryContext,
     build_run_summary_context,
@@ -100,14 +100,6 @@ def _build_default_output_filename(
     )
 
 
-def _print_results_to_screen(results: list[TestResult]) -> None:
-    """Print detailed per-test results to stdout as JSON."""
-    print(f"\nPrinting {len(results)} test result(s):")
-    for i, result in enumerate(results, 1):
-        print(f"\n--- Result {i}/{len(results)} ---")
-        print(json.dumps(result.to_dict(), indent=2, default=str))
-
-
 def _save_or_print_results(
     results: list[TestResult],
     *,
@@ -120,7 +112,7 @@ def _save_or_print_results(
         return
 
     if print_results:
-        _print_results_to_screen(results)
+        print_results_to_screen(results)
         return
 
     exporter = ResultExporter()

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -20,6 +20,9 @@ from gnw_evals.utils.sheet_registry import EVAL_SETS, get_sheet_url
 dotenv.load_dotenv()
 
 _OVERALL_SCORE_FIELD = "overall_score"
+_REASON_BY_SCORE = {
+    "agent_answer_score": "agent_answer_score_reason",
+}
 
 
 def _check_scores_from_result(result: TestResult) -> list[tuple[str, float]]:
@@ -87,6 +90,11 @@ def _print_failure_details(
     for name, score in failed_checks:
         label = name.removesuffix("_score").replace("_", " ")
         print(f"  {label}: {score}")
+        reason_field = _REASON_BY_SCORE.get(name)
+        if reason_field:
+            reason = getattr(result, reason_field, None)
+            if reason:
+                print(f"    reason: {reason}")
 
 
 def _build_default_output_filename(

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -23,6 +23,10 @@ _OVERALL_SCORE_FIELD = "overall_score"
 _REASON_BY_SCORE = {
     "agent_answer_score": "agent_answer_score_reason",
 }
+_PROACTIVE_ANALYSIS_PREFIX = (
+    "be proactive running the analysis, I am ok for you to make assumptions "
+    "about my question and prefer if you move forward with best possible pick"
+)
 
 
 def _check_scores_from_result(result: TestResult) -> list[tuple[str, float]]:
@@ -112,6 +116,16 @@ def _build_default_output_filename(
     )
 
 
+def _build_query_for_run(query: str, prepend_proactive_flag: bool) -> str:
+    """Optionally prepend proactive analysis guidance to each query."""
+    if not prepend_proactive_flag:
+        return query
+    clean_query = query.strip()
+    if not clean_query:
+        return _PROACTIVE_ANALYSIS_PREFIX
+    return f"{_PROACTIVE_ANALYSIS_PREFIX}\n\n{clean_query}"
+
+
 def _save_or_print_results(
     results: list[TestResult],
     *,
@@ -136,6 +150,7 @@ async def run_single_test(
     test_case,
     test_index,
     total_tests,
+    prepend_proactive_flag: bool = False,
 ) -> TestResult:
     """Run a single test case."""
     start_time = time.time()
@@ -145,7 +160,8 @@ async def run_single_test(
     expected_data = ExpectedData(
         **{k: v for k, v in test_dict.items() if k != "query"},
     )
-    result = await runner.run_test(test_case.query, expected_data)
+    run_query = _build_query_for_run(test_case.query, prepend_proactive_flag)
+    result = await runner.run_test(run_query, expected_data)
     duration = time.time() - start_time
     result.duration_seconds = duration
 
@@ -198,6 +214,7 @@ async def run_csv_tests(config) -> list[TestResult]:
                 test_case,
                 i,
                 len(test_cases),
+                config.prepend_proactive_flag,
             )
             results.append(result)
     else:
@@ -211,6 +228,7 @@ async def run_csv_tests(config) -> list[TestResult]:
                     test_case,
                     test_index,
                     len(test_cases),
+                    config.prepend_proactive_flag,
                 )
 
         # Create tasks for all tests
@@ -420,6 +438,13 @@ def _print_csv_summary(
     help="Random seed for sampling (0 means no random sampling) (can also be set via RANDOM_SEED env var)",
 )
 @click.option(
+    "--prepend-proactive-flag",
+    is_flag=True,
+    default=False,
+    envvar="PREPEND_PROACTIVE_FLAG",
+    help='Prepend "be proactive running the analysis..." guidance to each query',
+)
+@click.option(
     "--offset",
     default=0,
     type=int,
@@ -438,6 +463,7 @@ def run_evals(
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
+    prepend_proactive_flag: bool,
     offset: int,
 ):
     """Run main E2E test function for CSV based evaluation."""
@@ -467,6 +493,7 @@ def run_evals(
             output_filename=output_filename,
             num_workers=num_workers,
             random_seed=random_seed,
+            prepend_proactive_flag=prepend_proactive_flag,
             offset=offset,
         )
         return
@@ -497,6 +524,7 @@ def run_evals(
             output_filename=None,
             num_workers=num_workers,
             random_seed=random_seed,
+            prepend_proactive_flag=prepend_proactive_flag,
             offset=offset,
         )
 
@@ -530,6 +558,7 @@ def _run_custom_test_file(
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
+    prepend_proactive_flag: bool,
     offset: int,
 ) -> None:
     """Run evals with a custom test file (not from standard eval sets).
@@ -551,6 +580,7 @@ def _run_custom_test_file(
         output_filename=None,
         num_workers=num_workers,
         random_seed=random_seed,
+        prepend_proactive_flag=prepend_proactive_flag,
         offset=offset,
     )
 
@@ -585,6 +615,7 @@ def _run_single_eval_set(
     output_filename: str | None,
     num_workers: int,
     random_seed: int,
+    prepend_proactive_flag: bool,
     offset: int,
 ) -> list[TestResult]:
     """Run evals for a single eval set. Internal helper function.
@@ -618,6 +649,7 @@ EVALUATION CONFIGURATION
   Output Filename:   {output_filename or "Auto-generated"}
   Num Workers:       {num_workers}
   Random Seed:       {random_seed}
+  Proactive Prefix:  {prepend_proactive_flag}
   Offset:            {offset}
 ========================
 """,
@@ -646,6 +678,7 @@ EVALUATION CONFIGURATION
             self.output_filename = output_filename
             self.num_workers = num_workers
             self.random_seed = random_seed
+            self.prepend_proactive_flag = prepend_proactive_flag
             self.offset = offset
 
     config = Config()

--- a/src/gnw_evals/runners/api.py
+++ b/src/gnw_evals/runners/api.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime
+from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 import httpx
@@ -19,6 +20,26 @@ class APITestRunner(BaseTestRunner):
         self.api_base_url = api_base_url
         self.api_token = api_token
 
+    @staticmethod
+    def _build_app_thread_url(api_base_url: str, thread_id: str) -> str:
+        """Build GNW app thread URL from API base URL and session/thread ID."""
+        parsed = urlparse(api_base_url)
+        if not parsed.scheme or not parsed.netloc:
+            return f"{api_base_url.rstrip('/')}/app/threads/{thread_id}"
+
+        host = parsed.hostname or ""
+        if host in {"localhost", "127.0.0.1", "0.0.0.0"}:
+            return f"http://localhost:3000/app/threads/{thread_id}"
+
+        app_host = host.removeprefix("api.") if host.startswith("api.") else host
+        netloc = app_host
+        if parsed.port:
+            netloc = f"{app_host}:{parsed.port}"
+
+        return urlunparse(
+            (parsed.scheme, netloc, f"/app/threads/{thread_id}", "", "", ""),
+        )
+
     async def run_test(self, query: str, expected_data: ExpectedData) -> TestResult:
         """Run a single agent test using API endpoint.
 
@@ -32,6 +53,7 @@ class APITestRunner(BaseTestRunner):
         """
         thread_id = str(uuid4())
         trace_url = None
+        app_thread_url = self._build_app_thread_url(self.api_base_url, thread_id)
 
         try:
             # Collect all streaming responses to ensure conversation completes
@@ -100,6 +122,7 @@ class APITestRunner(BaseTestRunner):
 
             return TestResult(
                 thread_id=thread_id,
+                app_thread_url=app_thread_url,
                 trace_id=trace_id,
                 trace_url=trace_url,
                 query=query,
@@ -113,6 +136,7 @@ class APITestRunner(BaseTestRunner):
             return self._create_empty_evaluation_result(
                 thread_id,
                 trace_url or "",
+                app_thread_url,
                 query,
                 expected_data,
                 str(e),

--- a/src/gnw_evals/runners/base.py
+++ b/src/gnw_evals/runners/base.py
@@ -36,6 +36,7 @@ class BaseTestRunner(ABC):
         self,
         thread_id: str,
         trace_url: str,
+        app_thread_url: str | None,
         query: str,
         expected_data: ExpectedData,
         error: str,
@@ -52,6 +53,7 @@ class BaseTestRunner(ABC):
 
         return TestResult(
             thread_id=thread_id,
+            app_thread_url=app_thread_url,
             trace_id=None,
             trace_url=trace_url,
             query=query,

--- a/src/gnw_evals/utils/eval_types.py
+++ b/src/gnw_evals/utils/eval_types.py
@@ -11,6 +11,7 @@ class TestResult(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     thread_id: str
+    app_thread_url: str | None = None
     trace_id: str | None = None
     trace_url: str | None = None
     test_id: str = ""

--- a/src/gnw_evals/utils/result_display.py
+++ b/src/gnw_evals/utils/result_display.py
@@ -1,0 +1,221 @@
+"""Human-readable formatting for --print-results output."""
+
+from gnw_evals.utils.eval_types import TestResult
+
+_OVERALL_SCORE_FIELD = "overall_score"
+_MAX_LINE_WIDTH = 120
+_MAX_VALUE_WIDTH = 240
+
+# Fields never shown in comparisons (too large or redundant with scores).
+_SKIP_COMPARISON_ACTUALS = frozenset({"actual_charts_json"})
+
+# (expected_field, actual_field, optional score_field to gate on failure)
+_COMPARISONS: list[tuple[str, str, str | None]] = [
+    ("expected_aoi_ids", "actual_id", "aoi_id_match_score"),
+    ("expected_aoi_source", "actual_source", None),
+    ("expected_dataset_id", "actual_dataset_id", "dataset_id_match_score"),
+    ("expected_dataset_name", "actual_dataset_name", None),
+    (
+        "expected_dataset_parameters",
+        "actual_dataset_parameters",
+        "dataset_parameter_match_score",
+    ),
+    ("expected_context_layer", "actual_context_layer", "context_layer_match_score"),
+    ("expected_start_date", "actual_start_date", "date_match_score"),
+    ("expected_end_date", "actual_end_date", None),
+    ("expected_answer", "actual_charts_answer", "charts_answer_score"),
+    ("expected_text", "actual_agent_answer", "expected_text_match_score"),
+    (
+        "expected_clarification",
+        "actual_clarification_requested",
+        "clarification_requested_score",
+    ),
+]
+
+_REASON_BY_SCORE: dict[str, str] = {
+    "charts_answer_score": "chart_answer_score_reason",
+    "agent_answer_score": "agent_answer_score_reason",
+    "expected_text_match_score": "expected_text_match_score_reason",
+}
+
+
+def _is_empty(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, list):
+        return len(value) == 0
+    return False
+
+
+def _truncate(text: str, max_width: int) -> str:
+    text = " ".join(text.split())
+    if len(text) <= max_width:
+        return text
+    return text[: max_width - 3] + "..."
+
+
+def _format_value(value: object) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, list):
+        return "; ".join(str(item) for item in value) if value else "—"
+    text = str(value).strip()
+    if not text:
+        return "—"
+    return _truncate(text, _MAX_VALUE_WIDTH)
+
+
+def _score_fields(result: TestResult) -> list[tuple[str, float]]:
+    return [
+        (field, value)
+        for field, value in result.model_dump().items()
+        if field.endswith("_score") and value is not None
+    ]
+
+
+def _checks_passed(result: TestResult) -> bool:
+    if result.error:
+        return False
+    scores = [
+        (field, value)
+        for field, value in _score_fields(result)
+        if field != _OVERALL_SCORE_FIELD
+    ]
+    if not scores:
+        return True
+    return all(value == 1.0 for _, value in scores)
+
+
+def _should_show_comparison(
+    result: TestResult,
+    expected_field: str,
+    score_field: str | None,
+) -> bool:
+    expected = getattr(result, expected_field)
+    if not _is_empty(expected):
+        return True
+    if score_field is None:
+        return False
+    score = getattr(result, score_field)
+    return score is not None and score < 1.0
+
+
+def _comparison_label(field: str) -> str:
+    return field.removeprefix("expected_").replace("_", " ")
+
+
+def _format_scores(result: TestResult) -> list[str]:
+    lines: list[str] = []
+    for field, value in sorted(_score_fields(result)):
+        if field == _OVERALL_SCORE_FIELD:
+            continue
+        label = field.removesuffix("_score").replace("_", " ")
+        marker = "✓" if value == 1.0 else "✗"
+        lines.append(f"  {marker} {label}: {value}")
+        reason_field = _REASON_BY_SCORE.get(field)
+        if reason_field and value < 1.0:
+            reason = getattr(result, reason_field, None)
+            if reason:
+                lines.append(f"      → {_truncate(str(reason), _MAX_LINE_WIDTH)}")
+    return lines
+
+
+def _format_comparisons(result: TestResult) -> list[str]:
+    lines: list[str] = []
+    for expected_field, actual_field, score_field in _COMPARISONS:
+        if actual_field in _SKIP_COMPARISON_ACTUALS:
+            continue
+        if not _should_show_comparison(result, expected_field, score_field):
+            continue
+        label = _comparison_label(expected_field)
+        expected = _format_value(getattr(result, expected_field))
+        actual = _format_value(getattr(result, actual_field))
+        lines.append(f"  {label}:")
+        lines.append(f"    expected: {expected}")
+        lines.append(f"    actual:   {actual}")
+
+    if result.aoi_id_match_score is not None and result.aoi_id_match_score < 1.0:
+        for extra_field in ("actual_name", "actual_subtype"):
+            value = getattr(result, extra_field, None)
+            if not _is_empty(value):
+                label = extra_field.removeprefix("actual_").replace("_", " ")
+                lines.append(f"    {label}: {_format_value(value)}")
+
+    if (
+        result.data_pull_exists_score is not None
+        and result.data_pull_exists_score < 1.0
+        and result.row_count
+    ):
+        lines.append(f"  rows pulled: {result.row_count} (min {result.min_rows})")
+
+    return lines
+
+
+def format_test_result(result: TestResult, *, index: int, total: int) -> str:
+    """Format a single test result for terminal output."""
+    passed = _checks_passed(result)
+    status = "PASS" if passed else "FAIL"
+    test_id = result.test_id or f"#{index}"
+    duration = (
+        f"{result.duration_seconds:.1f}s"
+        if result.duration_seconds is not None
+        else result.execution_time
+    )
+
+    lines = [
+        f"[{status}] {test_id} ({index}/{total})"
+        f" | overall {result.overall_score} | {duration}",
+    ]
+    if result.eval_set and result.eval_set != "custom":
+        lines[0] += f" | {result.eval_set}"
+    if result.test_group and result.test_group != "unknown":
+        lines[0] += f" | group {result.test_group}"
+
+    query = (result.query or "").strip()
+    if query:
+        lines.append(f"  query: {_truncate(query, _MAX_LINE_WIDTH)}")
+
+    if result.trace_url:
+        lines.append(f"  trace: {result.trace_url}")
+
+    if result.error:
+        lines.append(f"  error: {_truncate(result.error, _MAX_VALUE_WIDTH)}")
+
+    score_lines = _format_scores(result)
+    if score_lines:
+        lines.append("  checks:")
+        lines.extend(score_lines)
+
+    comparison_lines = _format_comparisons(result)
+    if comparison_lines:
+        lines.append("  details:")
+        lines.extend(comparison_lines)
+
+    return "\n".join(lines)
+
+
+def print_results_to_screen(results: list[TestResult]) -> None:
+    """Print per-test results in a human-readable format."""
+    total = len(results)
+    passed = sum(1 for result in results if _checks_passed(result))
+    failed = total - passed
+
+    print(f"\n{'=' * 72}")
+    print(f"RESULTS ({total} test{'s' if total != 1 else ''})")
+    print(f"{'=' * 72}")
+
+    for index, result in enumerate(results, 1):
+        print()
+        print(format_test_result(result, index=index, total=total))
+
+    print()
+    print(f"{'—' * 72}")
+    print(f"Summary: {passed} passed, {failed} failed")
+    if total:
+        print(
+            f"Mean overall score: {sum(r.overall_score for r in results) / total:.3f}",
+        )

--- a/tests/test_result_display.py
+++ b/tests/test_result_display.py
@@ -1,0 +1,103 @@
+"""Tests for human-readable --print-results formatting."""
+
+from gnw_evals.utils.eval_types import TestResult
+from gnw_evals.utils.result_display import format_test_result, print_results_to_screen
+
+
+def _make_result(**overrides) -> TestResult:
+    defaults = {
+        "thread_id": "thread-1",
+        "query": "Show vegetation in AOI X",
+        "overall_score": 1.0,
+        "execution_time": "2025-01-01T00:00:00Z",
+        "duration_seconds": 3.5,
+        "test_id": "t-001",
+        "eval_set": "gold",
+        "aoi_id_match_score": 1.0,
+    }
+    defaults.update(overrides)
+    return TestResult(**defaults)
+
+
+def test_format_passing_result_shows_summary_not_json():
+    text = format_test_result(_make_result(), index=1, total=1)
+
+    assert "[PASS]" in text
+    assert "t-001" in text
+    assert "overall 1.0" in text
+    assert "Show vegetation" in text
+    assert "thread-1" not in text
+    assert "{" not in text
+
+
+def test_format_failing_result_shows_scores_and_comparisons():
+    text = format_test_result(
+        _make_result(
+            overall_score=0.5,
+            aoi_id_match_score=0.0,
+            expected_aoi_ids=["aoi-expected"],
+            actual_id="aoi-wrong",
+            actual_name="Wrong Place",
+            error=None,
+        ),
+        index=2,
+        total=5,
+    )
+
+    assert "[FAIL]" in text
+    assert "2/5" in text
+    assert "✗ aoi id match: 0.0" in text
+    assert "expected: aoi-expected" in text
+    assert "actual:   aoi-wrong" in text
+    assert "Wrong Place" in text
+
+
+def test_format_skips_empty_comparisons_and_large_json():
+    text = format_test_result(
+        _make_result(
+            actual_charts_json='{"huge": true}',
+            expected_dataset_id="",
+            dataset_id_match_score=1.0,
+        ),
+        index=1,
+        total=1,
+    )
+
+    assert "actual_charts_json" not in text
+    assert "details:" not in text
+
+
+def test_format_shows_score_reason_on_failure():
+    text = format_test_result(
+        _make_result(
+            overall_score=0.0,
+            charts_answer_score=0.0,
+            chart_answer_score_reason="Chart missing expected series",
+        ),
+        index=1,
+        total=1,
+    )
+
+    assert "Chart missing expected series" in text
+
+
+def test_print_results_to_screen_prints_summary(capsys):
+    print_results_to_screen(
+        [
+            _make_result(test_id="pass-1"),
+            _make_result(
+                test_id="fail-1",
+                overall_score=0.0,
+                aoi_id_match_score=0.0,
+                expected_aoi_ids=["x"],
+                actual_id="y",
+            ),
+        ],
+    )
+
+    out = capsys.readouterr().out
+    assert "RESULTS (2 tests)" in out
+    assert "Summary: 1 passed, 1 failed" in out
+    assert "Mean overall score:" in out
+    assert "[PASS] pass-1" in out
+    assert "[FAIL] fail-1" in out

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -12,8 +12,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from gnw_evals.core import _build_default_output_filename, run_csv_tests, run_evals
-from gnw_evals.utils.eval_types import ExpectedData
+from gnw_evals.core import (
+    _build_default_output_filename,
+    _print_failure_details,
+    run_csv_tests,
+    run_evals,
+)
+from gnw_evals.utils.eval_types import ExpectedData, TestResult
 
 
 class MockStreamContextManager:
@@ -1740,3 +1745,75 @@ def test_run_evals_with_no_results_writes_nothing():
     assert result.exit_code == 0
     mock_print.assert_not_called()
     mock_exporter_class.assert_not_called()
+
+
+def test_print_failure_details_includes_langfuse_link(capsys):
+    """Failing output should include app thread and trace URLs when available."""
+    test_case = ExpectedData(query="test question", test_id="test-123")
+    result = TestResult(
+        thread_id="thread-1",
+        app_thread_url="https://staging.globalnaturewatch.org/app/threads/thread-1",
+        query="test question",
+        overall_score=0.0,
+        execution_time="2026-01-01T00:00:00Z",
+        trace_url="https://langfuse.example/trace/abc123",
+        aoi_id_match_score=0.0,
+    )
+
+    _print_failure_details(
+        test_case=test_case,
+        test_index=0,
+        total_tests=1,
+        result=result,
+        duration=1.2,
+    )
+
+    out = capsys.readouterr().out
+    assert (
+        "app thread: https://staging.globalnaturewatch.org/app/threads/thread-1" in out
+    )
+    assert "langfuse: https://langfuse.example/trace/abc123" in out
+
+
+def test_build_app_thread_url_uses_thread_id_not_trace_id():
+    """App URL should map API host to app host and use session/thread UUID."""
+    from gnw_evals.runners.api import APITestRunner
+
+    url = APITestRunner._build_app_thread_url(
+        "https://api.staging.globalnaturewatch.org",
+        "2ebdb2fc-ed24-4b7e-b402-c043d468e940",
+    )
+
+    assert (
+        url
+        == "https://staging.globalnaturewatch.org/app/threads/2ebdb2fc-ed24-4b7e-b402-c043d468e940"
+    )
+
+
+def test_build_app_thread_url_uses_root_domain_for_production():
+    """Production API host should map to production app root domain."""
+    from gnw_evals.runners.api import APITestRunner
+
+    url = APITestRunner._build_app_thread_url(
+        "https://api.globalnaturewatch.org",
+        "2ebdb2fc-ed24-4b7e-b402-c043d468e940",
+    )
+
+    assert (
+        url
+        == "https://globalnaturewatch.org/app/threads/2ebdb2fc-ed24-4b7e-b402-c043d468e940"
+    )
+
+
+def test_build_app_thread_url_uses_localhost_3000_for_local_api():
+    """Local API hosts should point to local app at port 3000."""
+    from gnw_evals.runners.api import APITestRunner
+
+    url = APITestRunner._build_app_thread_url(
+        "http://localhost:8000",
+        "2ebdb2fc-ed24-4b7e-b402-c043d468e940",
+    )
+
+    assert (
+        url == "http://localhost:3000/app/threads/2ebdb2fc-ed24-4b7e-b402-c043d468e940"
+    )

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1775,6 +1775,31 @@ def test_print_failure_details_includes_langfuse_link(capsys):
     assert "langfuse: https://langfuse.example/trace/abc123" in out
 
 
+def test_print_failure_details_includes_agent_answer_failure_reason(capsys):
+    """Failing agent-answer checks should show the evaluator reason."""
+    test_case = ExpectedData(query="test question", test_id="test-123")
+    result = TestResult(
+        thread_id="thread-1",
+        query="test question",
+        overall_score=0.0,
+        execution_time="2026-01-01T00:00:00Z",
+        agent_answer_score=0.0,
+        agent_answer_score_reason="Answer picked Australia instead of Brazil.",
+    )
+
+    _print_failure_details(
+        test_case=test_case,
+        test_index=0,
+        total_tests=1,
+        result=result,
+        duration=1.2,
+    )
+
+    out = capsys.readouterr().out
+    assert "agent answer: 0.0" in out
+    assert "reason: Answer picked Australia instead of Brazil." in out
+
+
 def test_build_app_thread_url_uses_thread_id_not_trace_id():
     """App URL should map API host to app host and use session/thread UUID."""
     from gnw_evals.runners.api import APITestRunner

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -10,8 +10,9 @@ from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
-from gnw_evals.core import _build_default_output_filename, run_csv_tests
+from gnw_evals.core import _build_default_output_filename, run_csv_tests, run_evals
 from gnw_evals.utils.eval_types import ExpectedData
 
 
@@ -1704,3 +1705,38 @@ def test_default_output_filename_builder_for_all_eval_sets():
         offset=10,
     )
     assert filename == "eval_results_all_sample_5_workers_4_offset_10"
+
+
+def test_run_evals_print_results_skips_file_export():
+    """When --print-results is set, output should be printed, not saved."""
+    runner = CliRunner()
+    fake_result = MagicMock()
+
+    with patch("gnw_evals.core._run_single_eval_set", return_value=[fake_result]):
+        with patch("gnw_evals.core._print_results_to_screen") as mock_print:
+            with patch("gnw_evals.core.ResultExporter") as mock_exporter_class:
+                result = runner.invoke(
+                    run_evals,
+                    ["--api-token", "test-token", "--print-results"],
+                )
+
+    assert result.exit_code == 0
+    mock_print.assert_called_once()
+    mock_exporter_class.assert_not_called()
+
+
+def test_run_evals_with_no_results_writes_nothing():
+    """No CSV files or screen output when no tests are collected."""
+    runner = CliRunner()
+
+    with patch("gnw_evals.core._run_single_eval_set", return_value=[]):
+        with patch("gnw_evals.core._print_results_to_screen") as mock_print:
+            with patch("gnw_evals.core.ResultExporter") as mock_exporter_class:
+                result = runner.invoke(
+                    run_evals,
+                    ["--api-token", "test-token"],
+                )
+
+    assert result.exit_code == 0
+    mock_print.assert_not_called()
+    mock_exporter_class.assert_not_called()

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 
 from gnw_evals.core import (
     _build_default_output_filename,
+    _build_query_for_run,
     _print_failure_details,
     run_csv_tests,
     run_evals,
@@ -155,6 +156,7 @@ class TestConfig:
     output_filename: str = "test_results.csv"
     num_workers: int = 1
     random_seed: int = 0
+    prepend_proactive_flag: bool = False
     offset: int = 0
 
 
@@ -1842,3 +1844,22 @@ def test_build_app_thread_url_uses_localhost_3000_for_local_api():
     assert (
         url == "http://localhost:3000/app/threads/2ebdb2fc-ed24-4b7e-b402-c043d468e940"
     )
+
+
+def test_build_query_for_run_prepends_when_flag_enabled():
+    """Query should be prefixed with proactive guidance when enabled."""
+    query = "What changed in forest disturbance in 2024?"
+
+    updated_query = _build_query_for_run(query, prepend_proactive_flag=True)
+
+    assert updated_query.startswith("be proactive running the analysis")
+    assert updated_query.endswith(query)
+
+
+def test_build_query_for_run_noop_when_flag_disabled():
+    """Query should remain unchanged when proactive prefix is disabled."""
+    query = "Show me alerts in Brazil"
+
+    updated_query = _build_query_for_run(query, prepend_proactive_flag=False)
+
+    assert updated_query == query

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1713,7 +1713,7 @@ def test_run_evals_print_results_skips_file_export():
     fake_result = MagicMock()
 
     with patch("gnw_evals.core._run_single_eval_set", return_value=[fake_result]):
-        with patch("gnw_evals.core._print_results_to_screen") as mock_print:
+        with patch("gnw_evals.core.print_results_to_screen") as mock_print:
             with patch("gnw_evals.core.ResultExporter") as mock_exporter_class:
                 result = runner.invoke(
                     run_evals,
@@ -1730,7 +1730,7 @@ def test_run_evals_with_no_results_writes_nothing():
     runner = CliRunner()
 
     with patch("gnw_evals.core._run_single_eval_set", return_value=[]):
-        with patch("gnw_evals.core._print_results_to_screen") as mock_print:
+        with patch("gnw_evals.core.print_results_to_screen") as mock_print:
             with patch("gnw_evals.core.ResultExporter") as mock_exporter_class:
                 result = runner.invoke(
                     run_evals,


### PR DESCRIPTION
Try to prepend each query with a "be proactive" instruction.

Ran this on 10 questions and looked better than without it

```
==================================================
EVALUATION SUMMARY
==================================================
Environment:           localhost
API Base URL:          http://localhost:8000
Run timestamp:         2026-06-02 14:58:57 UTC
GNW code version:      2026.6.1
GNW prompts version:   unknown
GNW agent LLM:         primary gemini-flash (ChatGoogleGenerativeAI), small gemini-flash (ChatGoogleGenerativeAI)
Eval judge LLM:        Anthropic / claude-haiku-4-5
Test latency (s):      avg=70.2, std=60.6, min=20.8, max=190.9 (n=10)

Tests Run (after filters): 10

Agent Answer:               7 /   9 (0.78)

AOI ID Match:               7 /   7 (1.00)
Dataset ID Match:          10 /  10 (1.00)
Dataset Parameter Match:    0 /   0
Context Layer Match:        0 /   0
Data Pull Exists:           9 /   9 (1.00)
Date Match:                 7 /   7 (1.00)
Charts Answer:              5 /   5 (1.00)
Expected Text Match:        0 /   0
Clarification Requested:    0 /   0
```