### PR TITLE
Improve chart judge with CodeAct context and add verbose tool trace mode

### DIFF
--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -245,6 +245,7 @@ async def run_csv_tests(config) -> list[TestResult]:
         api_base_url=config.api_base_url,
         api_token=config.api_token,
         ff=getattr(config, "ff", None),
+        verbose=getattr(config, "verbose", False),
     )
     print(f"Using API endpoint: {config.api_base_url}")
 
@@ -482,6 +483,13 @@ def _print_csv_summary(
     envvar="FF",
     help="Feature flag selecting the agent tool profile, sent as the 'ff' field in the chat payload. Must be a lowercase slug (letters, digits, hyphens; max 64 chars). Requires an admin/machine token (can also be set via FF env var)",
 )
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    envvar="VERBOSE",
+    help="Print full API trace (streamed responses and agent state) for each test (can also be set via VERBOSE env var)",
+)
 def run_evals(
     api_base_url: str,
     api_token: str | None,
@@ -498,6 +506,7 @@ def run_evals(
     offset: int,
     num_trials: int,
     ff: str | None,
+    verbose: bool,
 ):
     """Run main E2E test function for CSV based evaluation."""
     # Validate API token
@@ -530,6 +539,7 @@ def run_evals(
             offset=offset,
             num_trials=num_trials,
             ff=ff,
+            verbose=verbose,
         )
         return
 
@@ -563,6 +573,7 @@ def run_evals(
             offset=offset,
             num_trials=num_trials,
             ff=ff,
+            verbose=verbose,
         )
 
         # Tag results with eval_set and accumulate
@@ -599,6 +610,7 @@ def _run_custom_test_file(
     offset: int,
     num_trials: int = 1,
     ff: str | None = None,
+    verbose: bool = False,
 ) -> None:
     """Run evals with a custom test file (not from standard eval sets).
 
@@ -623,6 +635,7 @@ def _run_custom_test_file(
         offset=offset,
         num_trials=num_trials,
         ff=ff,
+        verbose=verbose,
     )
 
     # Tag results with eval_set = "custom"
@@ -660,6 +673,7 @@ def _run_single_eval_set(
     offset: int,
     num_trials: int = 1,
     ff: str | None = None,
+    verbose: bool = False,
 ) -> list[TestResult]:
     """Run evals for a single eval set. Internal helper function.
 
@@ -696,6 +710,7 @@ EVALUATION CONFIGURATION
   Random Seed:       {random_seed}
   Offset:            {offset}
   Feature Flag:      {ff or "None"}
+  Verbose:           {verbose}
 ========================
 """,
     )
@@ -727,6 +742,7 @@ EVALUATION CONFIGURATION
             self.offset = offset
             self.num_trials = num_trials
             self.ff = ff
+            self.verbose = verbose
 
     config = Config()
     try:

--- a/src/gnw_evals/core.py
+++ b/src/gnw_evals/core.py
@@ -22,7 +22,9 @@ dotenv.load_dotenv()
 
 _OVERALL_SCORE_FIELD = "overall_score"
 _REASON_BY_SCORE = {
+    "charts_answer_score": "chart_answer_score_reason",
     "agent_answer_score": "agent_answer_score_reason",
+    "expected_text_match_score": "expected_text_match_score_reason",
 }
 
 
@@ -488,7 +490,7 @@ def _print_csv_summary(
     is_flag=True,
     default=False,
     envvar="VERBOSE",
-    help="Print full API trace (streamed responses and agent state) for each test (can also be set via VERBOSE env var)",
+    help="Print tool inputs and outputs for each test (can also be set via VERBOSE env var)",
 )
 def run_evals(
     api_base_url: str,

--- a/src/gnw_evals/evaluators/answer_evaluator.py
+++ b/src/gnw_evals/evaluators/answer_evaluator.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from typing import Any
 
@@ -6,6 +7,44 @@ from gnw_evals.evaluators.llm_judges import (
     llm_judge_chart,
     llm_judge_expected_text,
 )
+
+
+def _decode_codeact_parts(raw_parts: list[dict[str, Any]]) -> str:
+    """Decode base64-encoded codeact parts into a readable summary string.
+
+    The codeact_parts from agent state are stored with base64-encoded content.
+    Parts have types: 'code_block' (Python code), 'text_output' (LLM reasoning),
+    'execution_output' (printed stats/results).
+
+    Returns a formatted string grouped by type, capped at a reasonable length.
+    """
+    if not raw_parts:
+        return ""
+
+    grouped: dict[str, list[str]] = {}
+    for part in raw_parts:
+        part_type = part.get("type", "unknown")
+        content_b64 = part.get("content", "")
+        try:
+            decoded = base64.b64decode(content_b64).decode("utf-8")
+        except Exception:
+            decoded = content_b64  # fallback: use raw content
+
+        grouped.setdefault(part_type, []).append(decoded)
+
+    sections = []
+    type_labels = {
+        "code_block": "CODE",
+        "text_output": "LLM REASONING",
+        "execution_output": "EXECUTION OUTPUT",
+    }
+    for part_type, contents in grouped.items():
+        label = type_labels.get(part_type, part_type.upper())
+        combined = "\n---\n".join(contents)
+        combined = combined[:8000]
+        sections.append(f"## {label}\n\n{combined}")
+
+    return "\n\n".join(sections)
 
 
 def _serialize_chart_json(chart: dict[str, Any]) -> str:
@@ -79,6 +118,10 @@ def evaluate_final_answer(
             # Fallback for any other format
             actual_agent_answer = str(content) if content else ""
 
+    # Extract codeact parts (base64-encoded code/output from agent reasoning)
+    raw_codeact_parts = agent_state.get("codeact_parts", [])
+    codeact_summary = _decode_codeact_parts(raw_codeact_parts)
+
     # Score chart JSON, not prose insight text.
     charts_answer_score = None
     charts_answer_score_reason = None
@@ -88,6 +131,7 @@ def evaluate_final_answer(
                 query,
                 expected_answer,
                 actual_charts_json,
+                codeact_summary=codeact_summary,
                 include_reason=True,
             ),
         )
@@ -128,4 +172,5 @@ def evaluate_final_answer(
         "actual_charts_answer": actual_charts_answer or None,
         "actual_charts_json": actual_charts_json or None,
         "actual_agent_answer": actual_agent_answer or None,
+        "actual_codeact_summary": codeact_summary or None,
     }

--- a/src/gnw_evals/evaluators/llm_judges.py
+++ b/src/gnw_evals/evaluators/llm_judges.py
@@ -205,58 +205,93 @@ def llm_judge_chart(
     query: str,
     expected_answer: str,
     chart_json: str,
+    codeact_summary: str = "",
     include_reason: bool = False,
 ) -> int | dict[str, int | str]:
-    """Judge whether chart JSON is appropriate and supports the expected answer."""
+    """Judge whether chart JSON is appropriate and supports the expected answer.
+
+    Uses both the chart specification and the agent's code-act reasoning
+    (code blocks, execution output, analysis text) to evaluate whether
+    the chart is actually correct and answers the query.
+    """
 
     class ChartScore(BaseModel):
         reason: str
         score: int
 
+    codeact_section = ""
+    codeact_instruction = ""
+    if codeact_summary:
+        codeact_section = """
+
+CODEACT REASONING:
+{codeact_summary}
+
+This shows the code the agent executed, the intermediate results, and its
+analytical reasoning that led to the chart above."""
+        codeact_instruction = """
+
+If codeact reasoning is provided, use it to cross-check the chart data.
+If the code shows correct data processing but the chart specification has
+wrong metrics, filters, or structure, score 0 because the chart itself is
+flawed. If the code reveals incorrect analysis (e.g., wrong aggregation,
+wrong data source) even if the chart specification looks plausible on its
+own, also score 0.
+
+"""
+
+    full_prompt = (
+        """You are evaluating whether a chart specification is useful and correct for answering a user query.
+
+USER QUERY:
+{query}
+
+EXPECTED ANSWER:
+{expected_answer}
+
+CHART JSON:
+{chart_json}"""
+        + codeact_section
+        + """
+
+Score 1 if the chart JSON appears appropriate for the query and its encoded
+data, chart type, labels, dimensions, measures, filters, and time range would
+help a user verify or understand the expected answer.
+
+Score 0 if the chart is missing important data, uses the wrong
+metric/location/date range, has an unsuitable chart type for the comparison,
+contradicts the expected answer, or is too incomplete to judge.
+
+Do not score based on any prose insight or narrative answer. Focus on the
+chart specification, encoded data, labels, fields, and visual structure.
+
+"""
+        + codeact_instruction
+        + """Return:
+- score: 1 or 0
+- reason: one concise sentence explaining why you gave that score"""
+    )
+
     JUDGE_PROMPT = ChatPromptTemplate.from_messages(
         [
             (
                 "user",
-                """
-                You are evaluating whether a chart specification is useful and correct for answering a user query.
-
-                USER QUERY:
-                {query}
-
-                EXPECTED ANSWER:
-                {expected_answer}
-
-                CHART JSON:
-                {chart_json}
-
-                Score 1 if the chart JSON appears appropriate for the query and its encoded data, chart type,
-                labels, dimensions, measures, filters, and time range would help a user verify or understand the
-                expected answer.
-
-                Score 0 if the chart is missing important data, uses the wrong metric/location/date range,
-                has an unsuitable chart type for the comparison, contradicts the expected answer, or is too
-                incomplete to judge.
-
-                Do not score based on any prose insight or narrative answer. Focus on the chart specification,
-                encoded data, labels, fields, and visual structure.
-
-                Return:
-                - score: 1 or 0
-                - reason: one concise sentence explaining why you gave that score
-                """,
+                full_prompt,
             ),
         ],
     )
 
     judge_chain = JUDGE_PROMPT | HAIKU.with_structured_output(ChartScore)
 
-    llm_judgement = judge_chain.invoke(
-        {
-            "query": query,
-            "expected_answer": expected_answer,
-            "chart_json": chart_json,
-        },
-    )
+    invoke_kwargs = {
+        "query": query,
+        "expected_answer": expected_answer,
+        "chart_json": chart_json,
+    }
+    if codeact_summary:
+        invoke_kwargs["codeact_summary"] = codeact_summary
+
+    llm_judgement = judge_chain.invoke(invoke_kwargs)
 
     if include_reason:
         return {

--- a/src/gnw_evals/runners/api.py
+++ b/src/gnw_evals/runners/api.py
@@ -1,5 +1,6 @@
 """API test runner for E2E testing framework."""
 
+import base64
 import json
 from datetime import datetime
 from typing import Any
@@ -144,25 +145,6 @@ class APITestRunner(BaseTestRunner):
                         )
                         dashboard = None
 
-            # Print full trace in verbose mode
-            if self.verbose:
-                print("\n" + "=" * 70)
-                print("FULL TRACE")
-                print("=" * 70)
-                print(f"Query: {query}")
-                print(f"Thread ID: {thread_id}")
-                print(f"Trace ID: {trace_id}")
-                print(f"Trace URL: {trace_url}")
-                print("\n--- Streamed Responses ---")
-                for i, resp in enumerate(responses):
-                    print(f"[{i}] {json.dumps(resp, indent=2)}")
-                print("\n--- Agent State ---")
-                print(json.dumps(agent_state, indent=2, default=str))
-                if dashboard:
-                    print("\n--- Dashboard ---")
-                    print(json.dumps(dashboard, indent=2, default=str))
-                print("=" * 70 + "\n")
-
             # Run evaluations
             evaluations = self._run_evaluations(
                 agent_state,
@@ -171,6 +153,19 @@ class APITestRunner(BaseTestRunner):
                 dashboard,
             )
             overall_score = self._calculate_overall_score(evaluations, expected_data)
+
+            # Print tool trace in verbose mode
+            if self.verbose:
+                print(
+                    self._format_tool_trace(
+                        query,
+                        thread_id,
+                        trace_id,
+                        trace_url,
+                        agent_state,
+                        overall_score,
+                    ),
+                )
 
             kwargs = expected_data.to_dict()
             kwargs.update(evaluations)
@@ -202,3 +197,114 @@ class APITestRunner(BaseTestRunner):
                 expected_data,
                 str(e),
             )
+
+    @staticmethod
+    def _indent(text: str, prefix: str) -> str:
+        """Add prefix to each line of text."""
+        return "\n".join(f"{prefix}{line}" for line in text.split("\n"))
+
+    def _truncate(self, text: str, limit: int = 2000) -> str:
+        """Truncate long text with an ellipsis indicator."""
+        if len(text) <= limit:
+            return text
+        return text[:limit] + "\n... (truncated)"
+
+    def _format_tool_trace(
+        self,
+        query: str,
+        thread_id: str,
+        trace_id: str | None,
+        trace_url: str | None,
+        agent_state: dict[str, Any],
+        overall_score: float,
+    ) -> str:
+        """Format a human-readable tool trace for verbose output.
+
+        Extracts tool calls from messages (tool_call/tool_message pairs)
+        and decoded codeact_parts (code blocks and execution output),
+        presenting them in a step-by-step chronological format.
+        """
+        lines: list[str] = []
+        lines.append("=" * 70)
+        lines.append("TOOL TRACE")
+        lines.append("=" * 70)
+        lines.append(f"Query:     {query}")
+        lines.append(f"Thread ID: {thread_id}")
+        if trace_id:
+            lines.append(f"Trace ID:  {trace_id}")
+        if trace_url:
+            lines.append(f"Trace URL: {trace_url}")
+        lines.append(f"Score:     {overall_score}")
+
+        messages = agent_state.get("messages", [])
+        raw_parts = agent_state.get("codeact_parts", [])
+
+        # Extract tool call / tool message pairs from messages
+        tool_calls: list[dict[str, Any]] = []
+        for msg in messages:
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    if isinstance(tc, dict):
+                        tool_calls.append(
+                            {
+                                "name": tc.get("name", "unknown"),
+                                "args": tc.get("args", {}),
+                                "id": tc.get("id", ""),
+                            },
+                        )
+
+        # Match tool messages back to their calls
+        for msg in messages:
+            if hasattr(msg, "tool_call_id") and hasattr(msg, "content"):
+                tid = msg.tool_call_id
+                for tc in reversed(tool_calls):
+                    if tc["id"] == tid and "output" not in tc:
+                        tc["output"] = msg.content
+                        break
+
+        # Print tool calls from messages
+        if tool_calls:
+            lines.append("")
+            lines.append("--- Tool Calls ---")
+            for i, tc in enumerate(tool_calls, 1):
+                lines.append("")
+                lines.append(f"Tool {i}: {tc['name']}")
+                if tc["args"]:
+                    args_str = json.dumps(tc["args"], indent=2, default=str)
+                    lines.append(f"  Input:\n{self._indent(args_str, '    ')}")
+                if "output" in tc:
+                    output = str(tc["output"])
+                    output = self._truncate(output, 3000)
+                    lines.append(f"  Output:\n{self._indent(output, '    ')}")
+
+        # Decode and print codeact_parts
+        if raw_parts:
+            lines.append("")
+            lines.append("--- Execution Trace ---")
+            type_labels = {
+                "code_block": "CODE",
+                "text_output": "LLM",
+                "execution_output": "OUTPUT",
+            }
+            step = 0
+            for part in raw_parts:
+                part_type = part.get("type", "unknown")
+                try:
+                    content = base64.b64decode(
+                        part.get("content", ""),
+                    ).decode("utf-8")
+                except Exception:
+                    content = part.get("content", "")
+                label = type_labels.get(part_type, part_type.upper())
+                step += 1
+                content = self._truncate(content, 4000)
+                lines.append("")
+                lines.append(f"Step {step} [{label}]")
+                lines.append(self._indent(content, "    "))
+
+        if not tool_calls and not raw_parts:
+            lines.append("")
+            lines.append("(no tool trace available)")
+
+        lines.append("=" * 70)
+        return "\n".join(lines)

--- a/src/gnw_evals/runners/api.py
+++ b/src/gnw_evals/runners/api.py
@@ -21,11 +21,13 @@ class APITestRunner(BaseTestRunner):
         api_base_url: str,
         api_token: str | None = None,
         ff: str | None = None,
+        verbose: bool = False,
     ):
         """Initialize with API configuration."""
         self.api_base_url = api_base_url
         self.api_token = api_token
         self.ff = ff
+        self.verbose = verbose
 
     @staticmethod
     def _build_app_thread_url(api_base_url: str, thread_id: str) -> str:
@@ -141,6 +143,25 @@ class APITestRunner(BaseTestRunner):
                             f"{dashboard_error}",
                         )
                         dashboard = None
+
+            # Print full trace in verbose mode
+            if self.verbose:
+                print("\n" + "=" * 70)
+                print("FULL TRACE")
+                print("=" * 70)
+                print(f"Query: {query}")
+                print(f"Thread ID: {thread_id}")
+                print(f"Trace ID: {trace_id}")
+                print(f"Trace URL: {trace_url}")
+                print("\n--- Streamed Responses ---")
+                for i, resp in enumerate(responses):
+                    print(f"[{i}] {json.dumps(resp, indent=2)}")
+                print("\n--- Agent State ---")
+                print(json.dumps(agent_state, indent=2, default=str))
+                if dashboard:
+                    print("\n--- Dashboard ---")
+                    print(json.dumps(dashboard, indent=2, default=str))
+                print("=" * 70 + "\n")
 
             # Run evaluations
             evaluations = self._run_evaluations(

--- a/src/gnw_evals/utils/eval_types.py
+++ b/src/gnw_evals/utils/eval_types.py
@@ -86,6 +86,7 @@ class TestResult(BaseModel):
     actual_charts_answer: str | None = None
     actual_charts_json: str | None = None
     actual_agent_answer: str | None = None
+    actual_codeact_summary: str | None = None
 
     # Clarification evaluation fields
     actual_clarification_requested: bool | None = None

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1210,11 +1210,21 @@ def test_answer_evaluator_both_answers_present():
             ), "Should capture agent message"
 
             mock_chart_judge.assert_called_once()
+            mock_chart_judge.assert_called_with(
+                "Which country had more disturbed area, Brazil or Australia?",
+                "Brazil",
+                result["actual_charts_json"],
+                codeact_summary="",
+                include_reason=True,
+            )
             mock_judge.assert_called_once_with(
                 "Brazil",
                 "Based on the data, Australia has more.",
                 include_reason=True,
             )
+            assert (
+                result["actual_codeact_summary"] is None
+            ), "No codeact_parts should produce None summary"
 
 
 def test_answer_evaluator_no_charts_data():
@@ -1320,6 +1330,91 @@ def test_answer_evaluator_expected_text_match():
             agent_state["messages"][0].content,
             include_reason=True,
         )
+
+
+def test_answer_evaluator_with_codeact_parts():
+    """Test that codeact_parts are decoded and passed to the chart judge.
+
+    The codeact_parts from agent state are base64-encoded and contain
+    code blocks, execution output, and LLM reasoning. These should be
+    decoded and included in the chart evaluation so the judge can
+    cross-check the chart data against the agent's analysis.
+    """
+    import base64
+    from unittest.mock import patch
+
+    from gnw_evals.evaluators import evaluate_final_answer
+
+    code = base64.b64encode(b"print('total:', data['area'].sum())").decode()
+    output = base64.b64encode(b"total: 600.0").decode()
+    text = base64.b64encode(b"Summing disturbed area across countries.").decode()
+
+    agent_state = {
+        "charts_data": [
+            {
+                "insight": "Brazil has 500 hectares, Australia 100.",
+                "type": "bar",
+                "data": [
+                    {"country": "Brazil", "disturbed_area": 500},
+                    {"country": "Australia", "disturbed_area": 100},
+                ],
+                "encoding": {
+                    "x": {"field": "country"},
+                    "y": {"field": "disturbed_area"},
+                },
+            },
+        ],
+        "messages": [
+            type(
+                "obj",
+                (object,),
+                {"content": "Brazil has the most disturbed area."},
+            )(),
+        ],
+        "codeact_parts": [
+            {"type": "text_output", "content": text},
+            {"type": "code_block", "content": code},
+            {"type": "execution_output", "content": output},
+        ],
+    }
+
+    with patch("gnw_evals.evaluators.answer_evaluator.llm_judge") as mock_judge:
+        with patch(
+            "gnw_evals.evaluators.answer_evaluator.llm_judge_chart",
+        ) as mock_chart_judge:
+            mock_chart_judge.return_value = {
+                "score": 1.0,
+                "reason": "Chart and codeact reasoning both confirm the answer.",
+            }
+            mock_judge.return_value = {
+                "score": 1.0,
+                "reason": "The response identifies Brazil correctly.",
+            }
+
+            result = evaluate_final_answer(
+                agent_state=agent_state,
+                expected_answer="Brazil",
+                query="Which country had more disturbed area?",
+            )
+
+            assert result["charts_answer_score"] == 1.0
+            assert result["agent_answer_score"] == 1.0
+            assert result["actual_codeact_summary"] is not None
+            assert "## LLM REASONING" in result["actual_codeact_summary"]
+            assert "## CODE" in result["actual_codeact_summary"]
+            assert "## EXECUTION OUTPUT" in result["actual_codeact_summary"]
+            assert "Summing disturbed area" in result["actual_codeact_summary"]
+            assert "total: 600.0" in result["actual_codeact_summary"]
+
+            # Verify chart judge received the decoded codeact summary
+            mock_chart_judge.assert_called_once()
+            call_kwargs = mock_chart_judge.call_args
+            assert call_kwargs.kwargs.get("codeact_summary") or call_kwargs[1].get(
+                "codeact_summary",
+            )
+            codeact_passed = call_kwargs[1].get("codeact_summary", "")
+            assert "Summing disturbed area" in codeact_passed
+            assert "total: 600.0" in codeact_passed
 
 
 def test_overall_score_with_both_answer_scores():


### PR DESCRIPTION
## Summary
- Chart judge now receives the agent's CodeAct reasoning (decoded code blocks, execution output, and LLM reasoning) alongside the chart JSON, since chart data alone isn't always enough to judge whether a chart is correct
- Add a \`--verbose\`/\`VERBOSE\` flag to \`run_evals\` that prints a per-test tool trace: tool calls with inputs/outputs plus the decoded CodeAct execution steps, so failures are easier to debug
- \`TestResult\` gains an \`actual_codeact_summary\` field, and per-score reason columns are exported for \`charts_answer_score\` and \`expected_text_match_score\` in addition to \`agent_answer_score\`